### PR TITLE
feat: 添加 Twitch 直播监控插件

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -244,6 +244,7 @@ youtube:
 twitch:
   clientId:               # Twitch 应用的 Client ID
   clientSecret:           # Twitch 应用的 Client Secret
+  interval: 30s          # 轮询间隔，建议不要太短避免风控
   onlyOnlineNotify: false # 是否不推送Bot离线期间的直播，默认为false表示需要推送
 
 concern:

--- a/bot.go
+++ b/bot.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/douyu"
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/huya"
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/twitcasting"
+	_ "github.com/cnxysoft/DDBOT-WSa/lsp/twitch"
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/weibo"
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/youtube"
 	_ "github.com/cnxysoft/DDBOT-WSa/msg-marker"
@@ -237,6 +238,13 @@ weibo:
 
 youtube:
   onlyOnlineNotify: true  # 是否不推送Bot离线期间的动态和直播，默认为false表示需要推送，设置为true表示不推送
+
+# Twitch 直播推送
+# 需要在 https://dev.twitch.tv/console/apps 注册应用获取 clientId 和 clientSecret
+twitch:
+  clientId:               # Twitch 应用的 Client ID
+  clientSecret:           # Twitch 应用的 Client Secret
+  onlyOnlineNotify: false # 是否不推送Bot离线期间的直播，默认为false表示需要推送
 
 concern:
   emitInterval: 5s

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/douyu"
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/huya"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/permission"
+	_ "github.com/cnxysoft/DDBOT-WSa/lsp/twitch"
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/twitter"
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/weibo"
 	_ "github.com/cnxysoft/DDBOT-WSa/lsp/youtube"

--- a/lsp/cfg/config.go
+++ b/lsp/cfg/config.go
@@ -187,6 +187,10 @@ func GetAcfunOnlyOnlineNotify() bool {
 	return config.GlobalConfig.GetBool("acfun.onlyOnlineNotify")
 }
 
+func GetTwitchOnlyOnlineNotify() bool {
+	return config.GlobalConfig.GetBool("twitch.onlyOnlineNotify")
+}
+
 func GetWeiboMode() string {
 	mode := strings.TrimSpace(config.GlobalConfig.GetString("weibo.mode"))
 	if mode == "" {

--- a/lsp/template/default/notify.group.twitch.live.tmpl
+++ b/lsp/template/default/notify.group.twitch.live.tmpl
@@ -1,0 +1,10 @@
+{{ if .living -}}
+{{ .name }} 正在 Twitch 直播：
+标题: {{ .title }}
+游戏: {{ .game_name }}
+观看人数: {{ .viewer_count }}
+直播间: https://www.twitch.tv/{{ .login }}
+{{ pic .thumbnail "[封面获取失败]" }}
+{{- else -}}
+{{ .name }} 的 Twitch 直播已结束。
+{{- end -}}

--- a/lsp/twitch/api.go
+++ b/lsp/twitch/api.go
@@ -1,7 +1,10 @@
 package twitch
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +18,9 @@ const (
 	authURL = "https://id.twitch.tv/oauth2/token"
 	apiBase = "https://api.twitch.tv/helix"
 )
+
+// validLoginRegex Twitch用户名格式验证：4-25字符，字母数字下划线
+var validLoginRegex = regexp.MustCompile(`^[a-zA-Z0-9_]{4,25}$`)
 
 // appToken 缓存的 App Access Token
 type appToken struct {
@@ -74,6 +80,9 @@ type UsersResponse struct {
 	Data []UserData `json:"data"`
 }
 
+// ErrUserNotFound Twitch用户不存在
+var ErrUserNotFound = errors.New("twitch 用户不存在")
+
 // InitToken 初始化 token 存储的凭据信息
 func InitToken(clientId, clientSecret string) {
 	tokenStore.mu.Lock()
@@ -84,27 +93,41 @@ func InitToken(clientId, clientSecret string) {
 	logger.Debug("Twitch Token 凭据已初始化")
 }
 
-// getAccessToken 获取有效的 access token，过期时自动刷新
-func getAccessToken() (string, error) {
-	tokenStore.mu.Lock()
-	defer tokenStore.mu.Unlock()
-
-	// 检查 token 是否有效（留 60 秒缓冲）
-	if tokenStore.accessToken != "" {
-		elapsed := time.Since(tokenStore.fetchedAt)
-		if elapsed < time.Duration(tokenStore.expiresIn-60)*time.Second {
-			logger.Trace("Twitch Token 缓存命中，使用已有 Token")
-			return tokenStore.accessToken, nil
-		}
+// isTokenExpired 检查token是否即将过期（60秒缓冲）
+func isTokenExpired() bool {
+	if tokenStore.accessToken == "" {
+		return true
 	}
+	elapsed := time.Since(tokenStore.fetchedAt)
+	return elapsed >= time.Duration(tokenStore.expiresIn-60)*time.Second
+}
 
+// getAccessToken 获取有效的 access token，过期时自动刷新
+// 使用 double-checked locking 避免在HTTP请求期间持有锁
+func getAccessToken() (string, error) {
+	// 第一次检查：快速路径，缓存命中时无需加锁
+	tokenStore.mu.Lock()
+	if tokenStore.accessToken != "" && !isTokenExpired() {
+		token := tokenStore.accessToken
+		tokenStore.mu.Unlock()
+		return token, nil
+	}
+	// 记录旧token以便失败时回退
+	oldToken := tokenStore.accessToken
+	tokenStore.mu.Unlock()
+
+	// 检查凭据
+	tokenStore.mu.Lock()
 	if tokenStore.clientId == "" || tokenStore.clientSecret == "" {
+		tokenStore.mu.Unlock()
 		logger.Errorf("twitch clientId 或 clientSecret 未配置")
 		return "", fmt.Errorf("twitch clientId 或 clientSecret 未配置")
 	}
+	tokenStore.mu.Unlock()
 
 	logger.Debug("Twitch Token 已过期或不存在，正在刷新")
 
+	// 在锁外执行HTTP请求
 	var resp tokenResponse
 	err := requests.PostWWWForm(authURL, gout.H{
 		"client_id":     tokenStore.clientId,
@@ -117,20 +140,31 @@ func getAccessToken() (string, error) {
 	)
 	if err != nil {
 		logger.Errorf("获取 Twitch App Token 失败: %v", err)
+		// 失败时返回旧token（如果存在）
+		if oldToken != "" {
+			logger.Warn("Token刷新失败，使用旧Token")
+			return oldToken, nil
+		}
 		return "", fmt.Errorf("获取 Twitch App Token 失败: %w", err)
 	}
 	if resp.AccessToken == "" {
 		logger.Errorf("获取 Twitch App Token 失败: 响应为空")
+		if oldToken != "" {
+			return oldToken, nil
+		}
 		return "", fmt.Errorf("获取 Twitch App Token 失败: 响应为空")
 	}
 
+	// 更新token（持有锁）
+	tokenStore.mu.Lock()
 	tokenStore.accessToken = resp.AccessToken
 	tokenStore.expiresIn = resp.ExpiresIn
 	tokenStore.fetchedAt = time.Now()
+	tokenStore.mu.Unlock()
 
 	logger.WithField("expiresIn", resp.ExpiresIn).Debug("Twitch Token 刷新成功")
 
-	return tokenStore.accessToken, nil
+	return resp.AccessToken, nil
 }
 
 // apiOptions 返回 Twitch API 请求的通用选项
@@ -144,17 +178,89 @@ func apiOptions(token string) []requests.Option {
 	}
 }
 
-// GetStreamByLogin 根据用户登录名查询直播状态
-// 返回 StreamData 如果正在直播，nil 如果离线
-func GetStreamByLogin(login string) (*StreamData, error) {
+// buildLoginQuery 构建 user_login 查询参数
+func buildLoginQuery(logins []string) string {
+	var sb strings.Builder
+	for i, login := range logins {
+		if i > 0 {
+			sb.WriteByte('&')
+		}
+		sb.WriteString("user_login=")
+		sb.WriteString(url.QueryEscape(login))
+	}
+	return sb.String()
+}
+
+// GetStreamsByLogins 批量获取多个用户的直播状态
+// Twitch API 最多 100 个用户一次请求
+func GetStreamsByLogins(logins []string) ([]*StreamData, error) {
+	if len(logins) == 0 {
+		return nil, nil
+	}
+
 	token, err := getAccessToken()
 	if err != nil {
 		return nil, err
 	}
 
-	url := fmt.Sprintf("%s/streams?user_login=%s", apiBase, login)
+	var allStreams []*StreamData
+
+	// 分批处理，每批最多 100 个
+	for i := 0; i < len(logins); i += 100 {
+		end := i + 100
+		if end > len(logins) {
+			end = len(logins)
+		}
+		batch := logins[i:end]
+
+		streams, err := getStreamsBatch(token, batch)
+		if err != nil {
+			logger.Errorf("批量查询 Twitch 直播状态失败: %v", err)
+			return nil, err
+		}
+		// 转换为指针切片
+		for i := range streams {
+			allStreams = append(allStreams, &streams[i])
+		}
+	}
+
+	return allStreams, nil
+}
+
+// getStreamsBatch 批量查询一批用户的直播状态
+func getStreamsBatch(token string, logins []string) ([]StreamData, error) {
+	query := buildLoginQuery(logins)
+	urlStr := fmt.Sprintf("%s/streams?%s", apiBase, query)
+
 	var resp StreamsResponse
-	err = requests.Get(url, nil, &resp, apiOptions(token)...)
+	err := requests.Get(urlStr, nil, &resp, apiOptions(token)...)
+	if err != nil {
+		logger.WithField("logins", logins).Errorf("查询 Twitch 直播状态失败: %v", err)
+		return nil, fmt.Errorf("查询 Twitch 直播状态失败: %w", err)
+	}
+
+	logger.WithField("count", len(resp.Data)).Trace("批量查询直播状态成功")
+	return resp.Data, nil
+}
+
+// GetStreamByLogin 根据用户登录名查询直播状态
+// 返回 StreamData 如果正在直播，nil 如果离线
+func GetStreamByLogin(login string) (*StreamData, error) {
+	// 验证login格式
+	if !validLoginRegex.MatchString(login) {
+		return nil, fmt.Errorf("无效的 Twitch 用户名: %s", login)
+	}
+
+	token, err := getAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	query := buildLoginQuery([]string{login})
+	urlStr := fmt.Sprintf("%s/streams?%s", apiBase, query)
+
+	var resp StreamsResponse
+	err = requests.Get(urlStr, nil, &resp, apiOptions(token)...)
 	if err != nil {
 		logger.WithField("login", login).Errorf("查询 Twitch 直播状态失败: %v", err)
 		return nil, fmt.Errorf("查询 Twitch 直播状态失败 [%s]: %w", login, err)
@@ -170,14 +276,21 @@ func GetStreamByLogin(login string) (*StreamData, error) {
 
 // GetUserByLogin 根据用户登录名查询用户信息
 func GetUserByLogin(login string) (*UserData, error) {
+	// 验证login格式
+	if !validLoginRegex.MatchString(login) {
+		return nil, fmt.Errorf("无效的 Twitch 用户名: %s", login)
+	}
+
 	token, err := getAccessToken()
 	if err != nil {
 		return nil, err
 	}
 
-	url := fmt.Sprintf("%s/users?login=%s", apiBase, login)
+	query := buildLoginQuery([]string{login})
+	urlStr := fmt.Sprintf("%s/users?%s", apiBase, query)
+
 	var resp UsersResponse
-	err = requests.Get(url, nil, &resp, apiOptions(token)...)
+	err = requests.Get(urlStr, nil, &resp, apiOptions(token)...)
 	if err != nil {
 		logger.WithField("login", login).Errorf("查询 Twitch 用户信息失败: %v", err)
 		return nil, fmt.Errorf("查询 Twitch 用户信息失败 [%s]: %w", login, err)
@@ -192,8 +305,8 @@ func GetUserByLogin(login string) (*UserData, error) {
 }
 
 // FormatThumbnailURL 将 Twitch 缩略图 URL 中的 {width}x{height} 替换为实际尺寸
-func FormatThumbnailURL(url string, width, height int) string {
-	result := strings.ReplaceAll(url, "{width}", fmt.Sprintf("%d", width))
+func FormatThumbnailURL(urlStr string, width, height int) string {
+	result := strings.ReplaceAll(urlStr, "{width}", fmt.Sprintf("%d", width))
 	result = strings.ReplaceAll(result, "{height}", fmt.Sprintf("%d", height))
 	return result
 }

--- a/lsp/twitch/api.go
+++ b/lsp/twitch/api.go
@@ -178,14 +178,27 @@ func apiOptions(token string) []requests.Option {
 	}
 }
 
-// buildLoginQuery 构建 user_login 查询参数
-func buildLoginQuery(logins []string) string {
+// buildUserLoginQuery 构建 user_login 查询参数（用于 streams API）
+func buildUserLoginQuery(logins []string) string {
 	var sb strings.Builder
 	for i, login := range logins {
 		if i > 0 {
 			sb.WriteByte('&')
 		}
 		sb.WriteString("user_login=")
+		sb.WriteString(url.QueryEscape(login))
+	}
+	return sb.String()
+}
+
+// buildLoginQuery 构建 login 查询参数（用于 users API）
+func buildLoginQuery(logins []string) string {
+	var sb strings.Builder
+	for i, login := range logins {
+		if i > 0 {
+			sb.WriteByte('&')
+		}
+		sb.WriteString("login=")
 		sb.WriteString(url.QueryEscape(login))
 	}
 	return sb.String()
@@ -229,7 +242,7 @@ func GetStreamsByLogins(logins []string) ([]*StreamData, error) {
 
 // getStreamsBatch 批量查询一批用户的直播状态
 func getStreamsBatch(token string, logins []string) ([]StreamData, error) {
-	query := buildLoginQuery(logins)
+	query := buildUserLoginQuery(logins)
 	urlStr := fmt.Sprintf("%s/streams?%s", apiBase, query)
 
 	var resp StreamsResponse
@@ -256,7 +269,7 @@ func GetStreamByLogin(login string) (*StreamData, error) {
 		return nil, err
 	}
 
-	query := buildLoginQuery([]string{login})
+	query := buildUserLoginQuery([]string{login})
 	urlStr := fmt.Sprintf("%s/streams?%s", apiBase, query)
 
 	var resp StreamsResponse

--- a/lsp/twitch/api.go
+++ b/lsp/twitch/api.go
@@ -1,0 +1,199 @@
+package twitch
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cnxysoft/DDBOT-WSa/proxy_pool"
+	"github.com/cnxysoft/DDBOT-WSa/requests"
+	"github.com/guonaihong/gout"
+)
+
+const (
+	authURL = "https://id.twitch.tv/oauth2/token"
+	apiBase = "https://api.twitch.tv/helix"
+)
+
+// appToken 缓存的 App Access Token
+type appToken struct {
+	mu           sync.Mutex
+	accessToken  string
+	expiresIn    int
+	fetchedAt    time.Time
+	clientId     string
+	clientSecret string
+}
+
+var tokenStore = &appToken{}
+
+// tokenResponse 是 Twitch OAuth2 token 响应
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}
+
+// StreamData 表示 Twitch Helix streams 响应中的单个流
+type StreamData struct {
+	ID           string   `json:"id"`
+	UserID       string   `json:"user_id"`
+	UserLogin    string   `json:"user_login"`
+	UserName     string   `json:"user_name"`
+	GameID       string   `json:"game_id"`
+	GameName     string   `json:"game_name"`
+	Type         string   `json:"type"`
+	Title        string   `json:"title"`
+	ViewerCount  int      `json:"viewer_count"`
+	StartedAt    string   `json:"started_at"`
+	Language     string   `json:"language"`
+	ThumbnailURL string   `json:"thumbnail_url"`
+	Tags         []string `json:"tags"`
+	IsMature     bool     `json:"is_mature"`
+}
+
+// StreamsResponse 是 GET /helix/streams 响应
+type StreamsResponse struct {
+	Data []StreamData `json:"data"`
+}
+
+// UserData 表示 Twitch Helix users 响应中的单个用户
+type UserData struct {
+	ID              string `json:"id"`
+	Login           string `json:"login"`
+	DisplayName     string `json:"display_name"`
+	BroadcasterType string `json:"broadcaster_type"`
+	Description     string `json:"description"`
+	ProfileImageURL string `json:"profile_image_url"`
+	OfflineImageURL string `json:"offline_image_url"`
+}
+
+// UsersResponse 是 GET /helix/users 响应
+type UsersResponse struct {
+	Data []UserData `json:"data"`
+}
+
+// InitToken 初始化 token 存储的凭据信息
+func InitToken(clientId, clientSecret string) {
+	tokenStore.mu.Lock()
+	defer tokenStore.mu.Unlock()
+	tokenStore.clientId = clientId
+	tokenStore.clientSecret = clientSecret
+	tokenStore.accessToken = ""
+	logger.Debug("Twitch Token 凭据已初始化")
+}
+
+// getAccessToken 获取有效的 access token，过期时自动刷新
+func getAccessToken() (string, error) {
+	tokenStore.mu.Lock()
+	defer tokenStore.mu.Unlock()
+
+	// 检查 token 是否有效（留 60 秒缓冲）
+	if tokenStore.accessToken != "" {
+		elapsed := time.Since(tokenStore.fetchedAt)
+		if elapsed < time.Duration(tokenStore.expiresIn-60)*time.Second {
+			logger.Trace("Twitch Token 缓存命中，使用已有 Token")
+			return tokenStore.accessToken, nil
+		}
+	}
+
+	if tokenStore.clientId == "" || tokenStore.clientSecret == "" {
+		logger.Errorf("twitch clientId 或 clientSecret 未配置")
+		return "", fmt.Errorf("twitch clientId 或 clientSecret 未配置")
+	}
+
+	logger.Debug("Twitch Token 已过期或不存在，正在刷新")
+
+	var resp tokenResponse
+	err := requests.PostWWWForm(authURL, gout.H{
+		"client_id":     tokenStore.clientId,
+		"client_secret": tokenStore.clientSecret,
+		"grant_type":    "client_credentials",
+	}, &resp,
+		requests.TimeoutOption(time.Second*10),
+		requests.RetryOption(3),
+		requests.ProxyOption(proxy_pool.PreferOversea),
+	)
+	if err != nil {
+		logger.Errorf("获取 Twitch App Token 失败: %v", err)
+		return "", fmt.Errorf("获取 Twitch App Token 失败: %w", err)
+	}
+	if resp.AccessToken == "" {
+		logger.Errorf("获取 Twitch App Token 失败: 响应为空")
+		return "", fmt.Errorf("获取 Twitch App Token 失败: 响应为空")
+	}
+
+	tokenStore.accessToken = resp.AccessToken
+	tokenStore.expiresIn = resp.ExpiresIn
+	tokenStore.fetchedAt = time.Now()
+
+	logger.WithField("expiresIn", resp.ExpiresIn).Debug("Twitch Token 刷新成功")
+
+	return tokenStore.accessToken, nil
+}
+
+// apiOptions 返回 Twitch API 请求的通用选项
+func apiOptions(token string) []requests.Option {
+	return []requests.Option{
+		requests.HeaderOption("Client-Id", tokenStore.clientId),
+		requests.HeaderOption("Authorization", "Bearer "+token),
+		requests.TimeoutOption(time.Second * 10),
+		requests.RetryOption(3),
+		requests.ProxyOption(proxy_pool.PreferOversea),
+	}
+}
+
+// GetStreamByLogin 根据用户登录名查询直播状态
+// 返回 StreamData 如果正在直播，nil 如果离线
+func GetStreamByLogin(login string) (*StreamData, error) {
+	token, err := getAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/streams?user_login=%s", apiBase, login)
+	var resp StreamsResponse
+	err = requests.Get(url, nil, &resp, apiOptions(token)...)
+	if err != nil {
+		logger.WithField("login", login).Errorf("查询 Twitch 直播状态失败: %v", err)
+		return nil, fmt.Errorf("查询 Twitch 直播状态失败 [%s]: %w", login, err)
+	}
+
+	if len(resp.Data) == 0 {
+		logger.WithField("login", login).Trace("当前未直播")
+		return nil, nil // 离线
+	}
+	logger.WithField("login", login).WithField("title", resp.Data[0].Title).Trace("当前正在直播")
+	return &resp.Data[0], nil
+}
+
+// GetUserByLogin 根据用户登录名查询用户信息
+func GetUserByLogin(login string) (*UserData, error) {
+	token, err := getAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/users?login=%s", apiBase, login)
+	var resp UsersResponse
+	err = requests.Get(url, nil, &resp, apiOptions(token)...)
+	if err != nil {
+		logger.WithField("login", login).Errorf("查询 Twitch 用户信息失败: %v", err)
+		return nil, fmt.Errorf("查询 Twitch 用户信息失败 [%s]: %w", login, err)
+	}
+
+	if len(resp.Data) == 0 {
+		logger.WithField("login", login).Warn("Twitch 用户不存在")
+		return nil, ErrUserNotFound
+	}
+	logger.WithField("login", login).WithField("displayName", resp.Data[0].DisplayName).Trace("查询 Twitch 用户信息成功")
+	return &resp.Data[0], nil
+}
+
+// FormatThumbnailURL 将 Twitch 缩略图 URL 中的 {width}x{height} 替换为实际尺寸
+func FormatThumbnailURL(url string, width, height int) string {
+	result := strings.ReplaceAll(url, "{width}", fmt.Sprintf("%d", width))
+	result = strings.ReplaceAll(result, "{height}", fmt.Sprintf("%d", height))
+	return result
+}

--- a/lsp/twitch/api_test.go
+++ b/lsp/twitch/api_test.go
@@ -37,12 +37,20 @@ func TestValidLoginRegex(t *testing.T) {
 	}
 }
 
-func TestBuildLoginQuery(t *testing.T) {
+func TestBuildUserLoginQuery(t *testing.T) {
 	logins := []string{"user1", "user2", "user3"}
-	query := buildLoginQuery(logins)
+	query := buildUserLoginQuery(logins)
 	assert.Contains(t, query, "user_login=user1")
 	assert.Contains(t, query, "user_login=user2")
 	assert.Contains(t, query, "user_login=user3")
+}
+
+func TestBuildLoginQuery(t *testing.T) {
+	logins := []string{"user1", "user2", "user3"}
+	query := buildLoginQuery(logins)
+	assert.Contains(t, query, "login=user1")
+	assert.Contains(t, query, "login=user2")
+	assert.Contains(t, query, "login=user3")
 }
 
 func TestBuildLoginQueryEmpty(t *testing.T) {

--- a/lsp/twitch/api_test.go
+++ b/lsp/twitch/api_test.go
@@ -1,0 +1,71 @@
+package twitch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidLoginRegex(t *testing.T) {
+	validLogins := []string{
+		"testuser",
+		"test_user",
+		"TestUser123",
+		"abcd",
+		"abcde",
+		"abcdeabcdeabcdeabcdeabc", // 25 chars max
+	}
+
+	for _, login := range validLogins {
+		assert.True(t, validLoginRegex.MatchString(login), "login %q should be valid", login)
+	}
+
+	invalidLogins := []string{
+		"",
+		"abc",  // too short (< 4 chars)
+		"a",    // too short
+		"test!user",
+		"test user",
+		"test@user",
+		"test.user",
+		"a乙",
+		"abcdeabcdeabcdeabcdeabcdex", // 26 chars - too long (> 25 chars)
+	}
+
+	for _, login := range invalidLogins {
+		assert.False(t, validLoginRegex.MatchString(login), "login %q should be invalid", login)
+	}
+}
+
+func TestBuildLoginQuery(t *testing.T) {
+	logins := []string{"user1", "user2", "user3"}
+	query := buildLoginQuery(logins)
+	assert.Contains(t, query, "user_login=user1")
+	assert.Contains(t, query, "user_login=user2")
+	assert.Contains(t, query, "user_login=user3")
+}
+
+func TestBuildLoginQueryEmpty(t *testing.T) {
+	logins := []string{}
+	query := buildLoginQuery(logins)
+	assert.Equal(t, "", query)
+}
+
+func TestBuildLoginQuerySpecialChars(t *testing.T) {
+	logins := []string{"user name", "user@test"}
+	query := buildLoginQuery(logins)
+	assert.Contains(t, query, "user+name")
+	assert.Contains(t, query, "user%40test")
+}
+
+func TestFormatThumbnailURL(t *testing.T) {
+	original := "https://example.com/thumb-{width}x{height}.jpg"
+	result := FormatThumbnailURL(original, 1280, 720)
+	assert.Equal(t, "https://example.com/thumb-1280x720.jpg", result)
+}
+
+func TestFormatThumbnailURLNoPlaceholder(t *testing.T) {
+	original := "https://example.com/thumb.jpg"
+	result := FormatThumbnailURL(original, 1280, 720)
+	assert.Equal(t, original, result)
+}

--- a/lsp/twitch/concern.go
+++ b/lsp/twitch/concern.go
@@ -3,9 +3,12 @@ package twitch
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/Sora233/MiraiGo-Template/config"
 	"github.com/Sora233/MiraiGo-Template/utils"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/cfg"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/concern"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/concern_type"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/mmsg"
@@ -17,7 +20,13 @@ var logger = utils.GetModuleLogger("twitch-concern")
 const (
 	Site                   = "twitch"
 	Live concern_type.Type = "live"
+
+	// freshCount阈值：开播通知在count<1时发送，下播通知在count<3时发送
+	freshCountLiveThreshold   = int32(1)
+	freshCountOfflineThreshold = int32(3)
 )
+
+var online bool
 
 // userCache 缓存用户名映射 login -> displayName
 var userCache = sync.Map{}
@@ -34,6 +43,8 @@ func (sm *twitchStateManager) GetGroupConcernConfig(groupCode int64, id interfac
 // TwitchConcern 是 Twitch 直播监控的 Concern 实现
 type TwitchConcern struct {
 	*twitchStateManager
+	freshCount    atomic.Int32
+	freshStopChan chan struct{}
 }
 
 func (c *TwitchConcern) Site() string {
@@ -57,6 +68,15 @@ func (c *TwitchConcern) GetStateManager() concern.IStateManager {
 
 // Start 初始化 Twitch API 凭据并启动轮询
 func (c *TwitchConcern) Start() error {
+	c.freshStopChan = make(chan struct{})
+
+	var tickerStarted bool
+	defer func() {
+		if !tickerStarted {
+			close(c.freshStopChan)
+		}
+	}()
+
 	c.UseEmitQueue()
 
 	if config.GlobalConfig.Get("twitch") == nil {
@@ -82,6 +102,15 @@ func (c *TwitchConcern) Start() error {
 		return fmt.Errorf("Twitch API 认证失败: %w", err)
 	}
 
+	// 初始化 freshCount
+	if !cfg.GetTwitchOnlyOnlineNotify() {
+		c.freshCount.Store(1000) // 非 onlyOnlineNotify 模式，设置极大值
+	}
+
+	// 启动 freshCount 递增 goroutine
+	go c.freshCountTicker()
+	tickerStarted = true
+
 	c.UseFreshFunc(c.twitchFresh())
 	c.UseNotifyGeneratorFunc(c.twitchNotifyGenerator())
 
@@ -89,8 +118,32 @@ func (c *TwitchConcern) Start() error {
 	return c.StateManager.Start()
 }
 
+// freshCountTicker 每隔 concern.emitInterval 递增 freshCount
+func (c *TwitchConcern) freshCountTicker() {
+	interval := cfg.GetEmitInterval()
+	if interval <= 0 {
+		interval = time.Second * 5
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			// 每隔一个 emitInterval 递增 freshCount
+			c.freshCount.Add(1)
+			logger.Tracef("freshCount incremented to %d", c.freshCount.Load())
+		case <-c.freshStopChan:
+			return
+		}
+	}
+}
+
 func (c *TwitchConcern) Stop() {
 	logger.Trace("正在停止 twitch concern")
+	if c.freshStopChan != nil {
+		close(c.freshStopChan)
+	}
 	c.StateManager.Stop()
 	logger.Trace("twitch concern 已停止")
 }
@@ -187,22 +240,7 @@ func (c *TwitchConcern) twitchFresh() concern.FreshFunc {
 		last, hasLast := c.getLastStatus(login)
 
 		// 构造事件
-		event := &LiveEvent{
-			Id:    login,
-			Login: login,
-			Name:  c.getDisplayName(login),
-			Live:  isLive,
-		}
-
-		if isLive {
-			event.Title = stream.Title
-			event.GameName = stream.GameName
-			event.ViewerCount = stream.ViewerCount
-			event.ThumbnailURL = stream.ThumbnailURL
-			event.Name = stream.UserName
-			// 更新缓存
-			userCache.Store(login, stream.UserName)
-		}
+		event := c.buildLiveEvent(login, stream, isLive, hasLast, last)
 
 		// 判断状态变化
 		if hasLast && last.Live == isLive {
@@ -215,12 +253,20 @@ func (c *TwitchConcern) twitchFresh() concern.FreshFunc {
 			// 初始状态为离线，不推送
 			logger.Tracef("%v 的初始状态为下播，已略过。", login)
 			// 保存状态
-			c.updateLastStatus(login, &LastStatus{Live: false})
+			c.updateLastStatus(login, &LastStatus{Live: false, Title: ""})
 			return nil, nil
 		}
 
 		// 更新状态
-		c.updateLastStatus(login, &LastStatus{Live: isLive})
+		c.updateLastStatus(login, &LastStatus{Live: isLive, Title: event.Title})
+
+		currentCount := c.freshCount.Load()
+
+		// 根据 freshCount 决定是否发送
+		if !c.shouldNotify(event, currentCount) {
+			logger.Tracef("%v 的通知因 freshCount(%d) 被过滤", login, currentCount)
+			return nil, nil
+		}
 
 		if isLive {
 			logger.WithField("login", login).WithField("title", event.Title).Debug("检测到 Twitch 开播")
@@ -230,6 +276,51 @@ func (c *TwitchConcern) twitchFresh() concern.FreshFunc {
 
 		return []concern.Event{event}, nil
 	})
+}
+
+// shouldNotify 根据 freshCount 决定是否发送通知
+// 开播通知在 count < 1 时发送，下播通知在 count < 3 时发送
+func (c *TwitchConcern) shouldNotify(event *LiveEvent, count int32) bool {
+	if event.Live {
+		// 开播通知
+		return count < freshCountLiveThreshold
+	}
+	// 下播通知
+	return count < freshCountOfflineThreshold
+}
+
+// buildLiveEvent 构建直播事件
+func (c *TwitchConcern) buildLiveEvent(login string, stream *StreamData, isLive, hasLast bool, last *LastStatus) *LiveEvent {
+	event := &LiveEvent{
+		Id:    login,
+		Login: login,
+		Name:  c.getDisplayName(login),
+		Live:  isLive,
+	}
+
+	if isLive {
+		event.Title = stream.Title
+		event.GameName = stream.GameName
+		event.ViewerCount = stream.ViewerCount
+		event.ThumbnailURL = stream.ThumbnailURL
+		event.Name = stream.UserName
+		// 更新缓存
+		userCache.Store(login, stream.UserName)
+
+		// 检测标题变化
+		if hasLast && last.Title != "" && last.Title != event.Title {
+			event.titleChanged = true
+		}
+	}
+
+	// 判断状态变化
+	if !hasLast {
+		event.liveStatusChanged = true // 首次发现
+	} else if last.Live != isLive {
+		event.liveStatusChanged = true // 状态变化
+	}
+
+	return event
 }
 
 // twitchNotifyGenerator 创建通知生成函数
@@ -251,7 +342,8 @@ func (c *TwitchConcern) twitchNotifyGenerator() concern.NotifyGeneratorFunc {
 
 // LastStatus 记录上次的直播状态
 type LastStatus struct {
-	Live bool `json:"live"`
+	Live  bool   `json:"live"`
+	Title string `json:"title"`
 }
 
 func (c *TwitchConcern) getLastStatus(login string) (*LastStatus, bool) {
@@ -275,7 +367,7 @@ func (c *TwitchConcern) updateLastStatus(login string, status *LastStatus) {
 // NewConcern 创建新的 TwitchConcern 实例
 func NewConcern(notify chan<- concern.Notify) *TwitchConcern {
 	sm := &twitchStateManager{concern.NewStateManagerWithStringID(Site, notify)}
-	return &TwitchConcern{sm}
+	return &TwitchConcern{twitchStateManager: sm}
 }
 
 // init 向框架注册 Twitch 插件

--- a/lsp/twitch/concern.go
+++ b/lsp/twitch/concern.go
@@ -1,0 +1,284 @@
+package twitch
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/Sora233/MiraiGo-Template/config"
+	"github.com/Sora233/MiraiGo-Template/utils"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/concern"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/concern_type"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/mmsg"
+	localutils "github.com/cnxysoft/DDBOT-WSa/utils"
+)
+
+var logger = utils.GetModuleLogger("twitch-concern")
+
+const (
+	Site                   = "twitch"
+	Live concern_type.Type = "live"
+)
+
+// userCache 缓存用户名映射 login -> displayName
+var userCache = sync.Map{}
+
+// twitchStateManager 包装 concern.StateManager，覆盖 GetGroupConcernConfig
+type twitchStateManager struct {
+	*concern.StateManager
+}
+
+func (sm *twitchStateManager) GetGroupConcernConfig(groupCode int64, id interface{}) concern.IConfig {
+	return NewGroupConcernConfig(sm.StateManager.GetGroupConcernConfig(groupCode, id))
+}
+
+// TwitchConcern 是 Twitch 直播监控的 Concern 实现
+type TwitchConcern struct {
+	*twitchStateManager
+}
+
+func (c *TwitchConcern) Site() string {
+	return Site
+}
+
+func (c *TwitchConcern) Types() []concern_type.Type {
+	return []concern_type.Type{Live}
+}
+
+func (c *TwitchConcern) ParseId(s string) (interface{}, error) {
+	if s == "" {
+		return nil, fmt.Errorf("twitch 用户名不能为空")
+	}
+	return s, nil
+}
+
+func (c *TwitchConcern) GetStateManager() concern.IStateManager {
+	return c.StateManager
+}
+
+// Start 初始化 Twitch API 凭据并启动轮询
+func (c *TwitchConcern) Start() error {
+	c.UseEmitQueue()
+
+	if config.GlobalConfig.Get("twitch") == nil {
+		logger.Errorf("找不到 Twitch 配置，Twitch 订阅将不会启动")
+		return fmt.Errorf("找不到 Twitch 配置，Twitch 订阅将不会启动。")
+	}
+
+	clientId := config.GlobalConfig.GetString("twitch.clientId")
+	clientSecret := config.GlobalConfig.GetString("twitch.clientSecret")
+
+	if clientId == "" || clientSecret == "" {
+		logger.Errorf("twitch.clientId 和 twitch.clientSecret 不能为空，请在 application.yaml 中配置")
+		return fmt.Errorf("twitch.clientId 和 twitch.clientSecret 不能为空，请在 application.yaml 中配置")
+	}
+
+	logger.Debug("正在初始化 Twitch API 凭据")
+	InitToken(clientId, clientSecret)
+
+	// 验证凭据有效性
+	_, err := getAccessToken()
+	if err != nil {
+		logger.Errorf("Twitch API 认证失败: %v", err)
+		return fmt.Errorf("Twitch API 认证失败: %w", err)
+	}
+
+	c.UseFreshFunc(c.twitchFresh())
+	c.UseNotifyGeneratorFunc(c.twitchNotifyGenerator())
+
+	logger.Info("Twitch 订阅模块启动成功")
+	return c.StateManager.Start()
+}
+
+func (c *TwitchConcern) Stop() {
+	logger.Trace("正在停止 twitch concern")
+	c.StateManager.Stop()
+	logger.Trace("twitch concern 已停止")
+}
+
+// Add 添加一个 Twitch 订阅
+func (c *TwitchConcern) Add(ctx mmsg.IMsgCtx, groupCode int64, id interface{}, ctype concern_type.Type) (concern.IdentityInfo, error) {
+	login := id.(string)
+	log := logger.WithFields(localutils.GroupLogFields(groupCode)).WithField("login", login)
+
+	log.Debug("正在添加 Twitch 订阅")
+
+	// 验证用户存在
+	user, err := GetUserByLogin(login)
+	if err != nil {
+		log.Errorf("查询 Twitch 用户失败: %v", err)
+		return nil, fmt.Errorf("查询 Twitch 用户失败 [%s]: %v", login, err)
+	}
+
+	// 缓存用户名
+	userCache.Store(login, user.DisplayName)
+
+	_, err = c.GetStateManager().AddGroupConcern(groupCode, login, ctype)
+	if err != nil {
+		log.Errorf("AddGroupConcern error %v", err)
+		return nil, err
+	}
+
+	log.WithField("displayName", user.DisplayName).Info("Twitch 订阅添加成功")
+	return c.Get(id)
+}
+
+// Remove 删除一个 Twitch 订阅
+func (c *TwitchConcern) Remove(ctx mmsg.IMsgCtx, groupCode int64, id interface{}, ctype concern_type.Type) (concern.IdentityInfo, error) {
+	login := id.(string)
+	log := logger.WithFields(localutils.GroupLogFields(groupCode)).WithField("login", login)
+
+	log.Debug("正在移除 Twitch 订阅")
+	identity, _ := c.Get(id)
+
+	_, err := c.GetStateManager().RemoveGroupConcern(groupCode, login, ctype)
+	if err != nil {
+		log.Errorf("RemoveGroupConcern error %v", err)
+		return nil, err
+	}
+
+	log.Info("Twitch 订阅移除成功")
+	return identity, nil
+}
+
+// Get 获取订阅信息
+func (c *TwitchConcern) Get(id interface{}) (concern.IdentityInfo, error) {
+	login := id.(string)
+	displayName := c.getDisplayName(login)
+	name := fmt.Sprintf("%v(%v)", displayName, login)
+	return concern.NewIdentity(id, name), nil
+}
+
+// getDisplayName 从缓存或 API 获取用户显示名
+func (c *TwitchConcern) getDisplayName(login string) string {
+	if data, ok := userCache.Load(login); ok {
+		if name, ok := data.(string); ok {
+			logger.WithField("login", login).Trace("displayName 缓存命中")
+			return name
+		}
+	}
+
+	user, err := GetUserByLogin(login)
+	if err != nil {
+		logger.WithField("login", login).Warnf("获取用户名失败: %v", err)
+		return login
+	}
+
+	logger.WithField("login", login).WithField("displayName", user.DisplayName).Trace("displayName 已从 API 获取并缓存")
+	userCache.Store(login, user.DisplayName)
+	return user.DisplayName
+}
+
+// twitchFresh 创建轮询刷新函数
+func (c *TwitchConcern) twitchFresh() concern.FreshFunc {
+	return c.EmitQueueFresher(func(p concern_type.Type, id interface{}) ([]concern.Event, error) {
+		login := id.(string)
+
+		logger.Tracef("正在检测 Twitch 用户 (%v) 的直播状态..", login)
+
+		stream, err := GetStreamByLogin(login)
+		if err != nil {
+			logger.WithField("login", login).Errorf("GetStreamByLogin error %v", err)
+			return nil, err
+		}
+
+		isLive := stream != nil
+
+		// 获取上次状态
+		last, hasLast := c.getLastStatus(login)
+
+		// 构造事件
+		event := &LiveEvent{
+			Id:    login,
+			Login: login,
+			Name:  c.getDisplayName(login),
+			Live:  isLive,
+		}
+
+		if isLive {
+			event.Title = stream.Title
+			event.GameName = stream.GameName
+			event.ViewerCount = stream.ViewerCount
+			event.ThumbnailURL = stream.ThumbnailURL
+			event.Name = stream.UserName
+			// 更新缓存
+			userCache.Store(login, stream.UserName)
+		}
+
+		// 判断状态变化
+		if hasLast && last.Live == isLive {
+			// 状态无变化，不推送
+			logger.Tracef("%v 的直播状态与上次相同，已略过", login)
+			return nil, nil
+		}
+
+		if !hasLast && !isLive {
+			// 初始状态为离线，不推送
+			logger.Tracef("%v 的初始状态为下播，已略过。", login)
+			// 保存状态
+			c.updateLastStatus(login, &LastStatus{Live: false})
+			return nil, nil
+		}
+
+		// 更新状态
+		c.updateLastStatus(login, &LastStatus{Live: isLive})
+
+		if isLive {
+			logger.WithField("login", login).WithField("title", event.Title).Debug("检测到 Twitch 开播")
+		} else {
+			logger.WithField("login", login).Debug("检测到 Twitch 下播")
+		}
+
+		return []concern.Event{event}, nil
+	})
+}
+
+// twitchNotifyGenerator 创建通知生成函数
+func (c *TwitchConcern) twitchNotifyGenerator() concern.NotifyGeneratorFunc {
+	return func(groupCode int64, event concern.Event) []concern.Notify {
+		if liveEvent, ok := event.(*LiveEvent); ok {
+			liveEvent.Logger().WithFields(localutils.GroupLogFields(groupCode)).Trace("生成 Twitch 推送通知")
+			return []concern.Notify{
+				&LiveNotify{
+					groupCode: groupCode,
+					LiveEvent: *liveEvent,
+				},
+			}
+		}
+		logger.WithFields(localutils.GroupLogFields(groupCode)).Errorf("未知的 Twitch 事件类型")
+		return nil
+	}
+}
+
+// LastStatus 记录上次的直播状态
+type LastStatus struct {
+	Live bool `json:"live"`
+}
+
+func (c *TwitchConcern) getLastStatus(login string) (*LastStatus, bool) {
+	key := fmt.Sprintf("twitch_lastStatus_%s", login)
+	var status LastStatus
+	err := c.StateManager.GetJson(key, &status)
+	if err != nil {
+		return nil, false
+	}
+	return &status, true
+}
+
+func (c *TwitchConcern) updateLastStatus(login string, status *LastStatus) {
+	key := fmt.Sprintf("twitch_lastStatus_%s", login)
+	err := c.StateManager.SetJson(key, status)
+	if err != nil {
+		logger.Errorf("更新 Twitch 用户 %v 状态失败: %v", login, err)
+	}
+}
+
+// NewConcern 创建新的 TwitchConcern 实例
+func NewConcern(notify chan<- concern.Notify) *TwitchConcern {
+	sm := &twitchStateManager{concern.NewStateManagerWithStringID(Site, notify)}
+	return &TwitchConcern{sm}
+}
+
+// init 向框架注册 Twitch 插件
+func init() {
+	concern.RegisterConcern(NewConcern(concern.GetNotifyChan()))
+}

--- a/lsp/twitch/concern.go
+++ b/lsp/twitch/concern.go
@@ -130,8 +130,9 @@ func (c *TwitchConcern) Stop() {
 func (c *TwitchConcern) fresh() concern.FreshFunc {
 	return func(ctx context.Context, eventChan chan<- concern.Event) {
 		t := time.NewTimer(time.Second * 3)
-		interval := cfg.GetEmitIntervalForSite(Site)
-		if interval == 0 {
+		// 直接读取 twitch.interval，不使用 GetEmitIntervalForSite（它会 fallback 到 concern.emitInterval）
+		interval := config.GlobalConfig.GetDuration("twitch.interval")
+		if interval <= 0 {
 			interval = time.Second * 30
 		}
 		var freshCount atomic.Int32

--- a/lsp/twitch/concern.go
+++ b/lsp/twitch/concern.go
@@ -32,6 +32,11 @@ var online bool
 // userCache 缓存用户名映射 login -> displayName
 var userCache = sync.Map{}
 
+// UserInfoKey 返回用户信息的存储 key
+func UserInfoKey(login string) string {
+	return fmt.Sprintf("twitch:userinfo:%s", login)
+}
+
 // twitchStateManager 包装 concern.StateManager，覆盖 GetGroupConcernConfig
 type twitchStateManager struct {
 	*concern.StateManager
@@ -39,6 +44,24 @@ type twitchStateManager struct {
 
 func (sm *twitchStateManager) GetGroupConcernConfig(groupCode int64, id interface{}) concern.IConfig {
 	return NewGroupConcernConfig(sm.StateManager.GetGroupConcernConfig(groupCode, id))
+}
+
+// AddUserInfo 存储用户信息到 buntdb
+func (sm *twitchStateManager) AddUserInfo(user *UserData) error {
+	if user == nil {
+		return fmt.Errorf("nil UserInfo")
+	}
+	return sm.SetJson(UserInfoKey(user.Login), user)
+}
+
+// GetUserInfo 从 buntdb 获取用户信息
+func (sm *twitchStateManager) GetUserInfo(login string) (*UserData, error) {
+	var user UserData
+	err := sm.GetJson(UserInfoKey(login), &user)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
 }
 
 // TwitchConcern 是 Twitch 直播监控的 Concern 实现
@@ -233,6 +256,12 @@ func (c *TwitchConcern) buildLiveEvent(login string, stream *StreamData, isLive,
 		Live:  isLive,
 	}
 
+	// 获取用户信息（包含头像）
+	if user, err := c.GetUserInfo(login); err == nil {
+		event.ProfileImageURL = user.ProfileImageURL
+		event.OfflineImageURL = user.OfflineImageURL
+	}
+
 	if isLive && stream != nil {
 		event.Title = stream.Title
 		event.GameName = stream.GameName
@@ -263,14 +292,53 @@ func (c *TwitchConcern) Add(ctx mmsg.IMsgCtx, groupCode int64, id interface{}, c
 	// 缓存用户名
 	userCache.Store(login, user.DisplayName)
 
+	// 存储用户信息到 buntdb
+	if err := c.AddUserInfo(user); err != nil {
+		log.Warnf("存储用户信息失败: %v", err)
+	}
+
 	_, err = c.GetStateManager().AddGroupConcern(groupCode, login, ctype)
 	if err != nil {
 		log.Errorf("AddGroupConcern error %v", err)
 		return nil, err
 	}
 
+	// 如果用户正在直播，发送通知
+	if ctype.ContainAny(Live) {
+		stream, err := GetStreamByLogin(login)
+		if err == nil && stream != nil {
+			event := c.buildLiveEvent(login, stream, true, false, nil)
+			event.liveStatusChanged = true
+			if ctx.GetTarget().TargetType().IsGroup() {
+				defer c.GroupWatchNotify(groupCode, login)
+			}
+			if ctx.GetTarget().TargetType().IsPrivate() {
+				defer func() {
+					ctx.Send(mmsg.NewText("检测到该用户正在直播，但由于您目前处于私聊模式，" +
+						"因此不会在群内推送本次直播，将在该用户下次直播时推送"))
+				}()
+			}
+			_ = event // event 会在 GroupWatchNotify 中使用
+		}
+	}
+
 	log.WithField("displayName", user.DisplayName).Info("Twitch 订阅添加成功")
 	return c.Get(id)
+}
+
+// GroupWatchNotify 向指定群发送直播通知
+func (c *TwitchConcern) GroupWatchNotify(groupCode int64, login string) {
+	stream, err := GetStreamByLogin(login)
+	if err != nil || stream == nil {
+		return
+	}
+	event := c.buildLiveEvent(login, stream, true, false, nil)
+	event.liveStatusChanged = true
+	notify := &LiveNotify{
+		groupCode: groupCode,
+		LiveEvent: *event,
+	}
+	concern.GetNotifyChan() <- notify
 }
 
 // Remove 删除一个 Twitch 订阅
@@ -299,7 +367,7 @@ func (c *TwitchConcern) Get(id interface{}) (concern.IdentityInfo, error) {
 	return concern.NewIdentity(id, name), nil
 }
 
-// getDisplayName 从缓存或 API 获取用户显示名
+// getDisplayName 从缓存或 API 获取用户显示名，同时刷新用户信息
 func (c *TwitchConcern) getDisplayName(login string) string {
 	if data, ok := userCache.Load(login); ok {
 		if name, ok := data.(string); ok {
@@ -316,6 +384,12 @@ func (c *TwitchConcern) getDisplayName(login string) string {
 
 	logger.WithField("login", login).WithField("displayName", user.DisplayName).Trace("displayName 已从 API 获取并缓存")
 	userCache.Store(login, user.DisplayName)
+
+	// 刷新 buntdb 中的用户信息
+	if err := c.AddUserInfo(user); err != nil {
+		logger.WithField("login", login).Warnf("刷新用户信息失败: %v", err)
+	}
+
 	return user.DisplayName
 }
 

--- a/lsp/twitch/concern.go
+++ b/lsp/twitch/concern.go
@@ -1,6 +1,7 @@
 package twitch
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -22,7 +23,7 @@ const (
 	Live concern_type.Type = "live"
 
 	// freshCount阈值：开播通知在count<1时发送，下播通知在count<3时发送
-	freshCountLiveThreshold   = int32(1)
+	freshCountLiveThreshold    = int32(1)
 	freshCountOfflineThreshold = int32(3)
 )
 
@@ -43,8 +44,6 @@ func (sm *twitchStateManager) GetGroupConcernConfig(groupCode int64, id interfac
 // TwitchConcern 是 Twitch 直播监控的 Concern 实现
 type TwitchConcern struct {
 	*twitchStateManager
-	freshCount    atomic.Int32
-	freshStopChan chan struct{}
 }
 
 func (c *TwitchConcern) Site() string {
@@ -68,17 +67,6 @@ func (c *TwitchConcern) GetStateManager() concern.IStateManager {
 
 // Start 初始化 Twitch API 凭据并启动轮询
 func (c *TwitchConcern) Start() error {
-	c.freshStopChan = make(chan struct{})
-
-	var tickerStarted bool
-	defer func() {
-		if !tickerStarted {
-			close(c.freshStopChan)
-		}
-	}()
-
-	c.UseEmitQueue()
-
 	if config.GlobalConfig.Get("twitch") == nil {
 		logger.Errorf("找不到 Twitch 配置，Twitch 订阅将不会启动")
 		return fmt.Errorf("找不到 Twitch 配置，Twitch 订阅将不会启动。")
@@ -102,50 +90,160 @@ func (c *TwitchConcern) Start() error {
 		return fmt.Errorf("Twitch API 认证失败: %w", err)
 	}
 
-	// 初始化 freshCount
-	if !cfg.GetTwitchOnlyOnlineNotify() {
-		c.freshCount.Store(1000) // 非 onlyOnlineNotify 模式，设置极大值
-	}
-
-	// 启动 freshCount 递增 goroutine
-	go c.freshCountTicker()
-	tickerStarted = true
-
-	c.UseFreshFunc(c.twitchFresh())
+	c.UseFreshFunc(c.fresh())
 	c.UseNotifyGeneratorFunc(c.twitchNotifyGenerator())
 
 	logger.Info("Twitch 订阅模块启动成功")
 	return c.StateManager.Start()
 }
 
-// freshCountTicker 每隔 concern.emitInterval 递增 freshCount
-func (c *TwitchConcern) freshCountTicker() {
-	interval := cfg.GetEmitInterval()
-	if interval <= 0 {
-		interval = time.Second * 5
-	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+func (c *TwitchConcern) Stop() {
+	logger.Trace("正在停止 twitch concern")
+	c.StateManager.Stop()
+	logger.Trace("twitch concern 已停止")
+}
 
-	for {
-		select {
-		case <-ticker.C:
-			// 每隔一个 emitInterval 递增 freshCount
-			c.freshCount.Add(1)
-			logger.Tracef("freshCount incremented to %d", c.freshCount.Load())
-		case <-c.freshStopChan:
-			return
+// fresh 是自定义刷新函数，实现 Bilibili 风格的过滤机制
+func (c *TwitchConcern) fresh() concern.FreshFunc {
+	return func(ctx context.Context, eventChan chan<- concern.Event) {
+		t := time.NewTimer(time.Second * 3)
+		interval := cfg.GetEmitIntervalForSite(Site)
+		if interval == 0 {
+			interval = time.Second * 30
+		}
+		var freshCount atomic.Int32
+		if !cfg.GetTwitchOnlyOnlineNotify() {
+			freshCount.Store(1000)
+		}
+		for {
+			select {
+			case <-t.C:
+			case <-ctx.Done():
+				return
+			}
+			start := time.Now()
+
+			// 获取所有 Twitch 订阅
+			_, ids, types, err := c.StateManager.ListConcernState(
+				func(groupCode int64, id interface{}, p concern_type.Type) bool {
+					return p.ContainAny(Live)
+				})
+			if err != nil {
+				logger.Errorf("ListConcernState error %v", err)
+			}
+
+			// 提取所有 login
+			var logins []string
+			for _, id := range ids {
+				if login, ok := id.(string); ok {
+					logins = append(logins, login)
+				}
+			}
+
+			// 批量查询所有用户的直播状态
+			liveMap := make(map[string]*StreamData)
+			if len(logins) > 0 {
+				streams, err := GetStreamsByLogins(logins)
+				if err != nil {
+					logger.Errorf("GetStreamsByLogins error %v", err)
+				} else {
+					for i := range streams {
+						liveMap[streams[i].UserLogin] = streams[i]
+					}
+				}
+			}
+
+			// 过滤出有效的订阅类型
+			ids, _, err = c.GroupTypeById(ids, types)
+			if err != nil {
+				logger.Errorf("GroupTypeById error %v", err)
+			}
+
+			// 逐个检查状态变化
+			for _, id := range ids {
+				login := id.(string)
+				stream, isLive := liveMap[login]
+				last, hasLast := c.getLastStatus(login)
+
+				if !hasLast {
+					// 首次状态
+					title := ""
+					if isLive {
+						event := c.buildLiveEvent(login, stream, isLive, false, nil)
+						title = event.Title
+						if freshCount.Load() < freshCountLiveThreshold {
+							event.liveStatusChanged = true
+							eventChan <- event
+						}
+					}
+					c.updateLastStatus(login, &LastStatus{Live: isLive, Title: title})
+					continue
+				}
+
+				if last.Live == isLive {
+					// 状态无变化
+					if isLive && stream != nil {
+						// 检查标题变化
+						if last.Title != "" && last.Title != stream.Title {
+							event := c.buildLiveEvent(login, stream, isLive, hasLast, last)
+							event.titleChanged = true
+							event.liveStatusChanged = false
+							if freshCount.Load() < freshCountLiveThreshold {
+								eventChan <- event
+							}
+							c.updateLastStatus(login, &LastStatus{Live: isLive, Title: stream.Title})
+						}
+					}
+					continue
+				}
+
+				// 状态变化
+				event := c.buildLiveEvent(login, stream, isLive, hasLast, last)
+
+				if isLive {
+					// 开播
+					if freshCount.Load() < freshCountLiveThreshold {
+						event.liveStatusChanged = true
+						eventChan <- event
+					}
+				} else {
+					// 下播
+					if freshCount.Load() < freshCountOfflineThreshold {
+						event.liveStatusChanged = true
+						eventChan <- event
+					}
+				}
+				c.updateLastStatus(login, &LastStatus{Live: isLive, Title: event.Title})
+			}
+
+			freshCount.Add(1)
+			end := time.Now()
+			logger.WithField("cost", end.Sub(start)).Tracef("twitch fresh loop done")
+			t.Reset(interval)
 		}
 	}
 }
 
-func (c *TwitchConcern) Stop() {
-	logger.Trace("正在停止 twitch concern")
-	if c.freshStopChan != nil {
-		close(c.freshStopChan)
+// buildLiveEvent 构建直播事件
+func (c *TwitchConcern) buildLiveEvent(login string, stream *StreamData, isLive, hasLast bool, last *LastStatus) *LiveEvent {
+	event := &LiveEvent{
+		Id:    login,
+		Login: login,
+		Name:  c.getDisplayName(login),
+		Live:  isLive,
 	}
-	c.StateManager.Stop()
-	logger.Trace("twitch concern 已停止")
+
+	if isLive && stream != nil {
+		event.Title = stream.Title
+		event.GameName = stream.GameName
+		event.ViewerCount = stream.ViewerCount
+		event.ThumbnailURL = stream.ThumbnailURL
+		event.Name = stream.UserName
+		// 更新缓存
+		userCache.Store(login, stream.UserName)
+	}
+
+	return event
 }
 
 // Add 添加一个 Twitch 订阅
@@ -219,108 +317,6 @@ func (c *TwitchConcern) getDisplayName(login string) string {
 	logger.WithField("login", login).WithField("displayName", user.DisplayName).Trace("displayName 已从 API 获取并缓存")
 	userCache.Store(login, user.DisplayName)
 	return user.DisplayName
-}
-
-// twitchFresh 创建轮询刷新函数
-func (c *TwitchConcern) twitchFresh() concern.FreshFunc {
-	return c.EmitQueueFresher(func(p concern_type.Type, id interface{}) ([]concern.Event, error) {
-		login := id.(string)
-
-		logger.Tracef("正在检测 Twitch 用户 (%v) 的直播状态..", login)
-
-		stream, err := GetStreamByLogin(login)
-		if err != nil {
-			logger.WithField("login", login).Errorf("GetStreamByLogin error %v", err)
-			return nil, err
-		}
-
-		isLive := stream != nil
-
-		// 获取上次状态
-		last, hasLast := c.getLastStatus(login)
-
-		// 构造事件
-		event := c.buildLiveEvent(login, stream, isLive, hasLast, last)
-
-		// 判断状态变化
-		if hasLast && last.Live == isLive {
-			// 状态无变化，不推送
-			logger.Tracef("%v 的直播状态与上次相同，已略过", login)
-			return nil, nil
-		}
-
-		if !hasLast && !isLive {
-			// 初始状态为离线，不推送
-			logger.Tracef("%v 的初始状态为下播，已略过。", login)
-			// 保存状态
-			c.updateLastStatus(login, &LastStatus{Live: false, Title: ""})
-			return nil, nil
-		}
-
-		// 更新状态
-		c.updateLastStatus(login, &LastStatus{Live: isLive, Title: event.Title})
-
-		currentCount := c.freshCount.Load()
-
-		// 根据 freshCount 决定是否发送
-		if !c.shouldNotify(event, currentCount) {
-			logger.Tracef("%v 的通知因 freshCount(%d) 被过滤", login, currentCount)
-			return nil, nil
-		}
-
-		if isLive {
-			logger.WithField("login", login).WithField("title", event.Title).Debug("检测到 Twitch 开播")
-		} else {
-			logger.WithField("login", login).Debug("检测到 Twitch 下播")
-		}
-
-		return []concern.Event{event}, nil
-	})
-}
-
-// shouldNotify 根据 freshCount 决定是否发送通知
-// 开播通知在 count < 1 时发送，下播通知在 count < 3 时发送
-func (c *TwitchConcern) shouldNotify(event *LiveEvent, count int32) bool {
-	if event.Live {
-		// 开播通知
-		return count < freshCountLiveThreshold
-	}
-	// 下播通知
-	return count < freshCountOfflineThreshold
-}
-
-// buildLiveEvent 构建直播事件
-func (c *TwitchConcern) buildLiveEvent(login string, stream *StreamData, isLive, hasLast bool, last *LastStatus) *LiveEvent {
-	event := &LiveEvent{
-		Id:    login,
-		Login: login,
-		Name:  c.getDisplayName(login),
-		Live:  isLive,
-	}
-
-	if isLive {
-		event.Title = stream.Title
-		event.GameName = stream.GameName
-		event.ViewerCount = stream.ViewerCount
-		event.ThumbnailURL = stream.ThumbnailURL
-		event.Name = stream.UserName
-		// 更新缓存
-		userCache.Store(login, stream.UserName)
-
-		// 检测标题变化
-		if hasLast && last.Title != "" && last.Title != event.Title {
-			event.titleChanged = true
-		}
-	}
-
-	// 判断状态变化
-	if !hasLast {
-		event.liveStatusChanged = true // 首次发现
-	} else if last.Live != isLive {
-		event.liveStatusChanged = true // 状态变化
-	}
-
-	return event
 }
 
 // twitchNotifyGenerator 创建通知生成函数

--- a/lsp/twitch/config.go
+++ b/lsp/twitch/config.go
@@ -1,0 +1,17 @@
+package twitch
+
+import (
+	"github.com/cnxysoft/DDBOT-WSa/lsp/concern"
+)
+
+type GroupConcernConfig struct {
+	concern.IConfig
+}
+
+func (g *GroupConcernConfig) ShouldSendHook(notify concern.Notify) *concern.HookResult {
+	return concern.HookResultPass
+}
+
+func NewGroupConcernConfig(g concern.IConfig) *GroupConcernConfig {
+	return &GroupConcernConfig{g}
+}

--- a/lsp/twitch/config.go
+++ b/lsp/twitch/config.go
@@ -9,7 +9,8 @@ type GroupConcernConfig struct {
 }
 
 func (g *GroupConcernConfig) ShouldSendHook(notify concern.Notify) *concern.HookResult {
-	return concern.HookResultPass
+	// 委托给基类处理 OfflineNotify 和 TitleChangeNotify 配置检查
+	return g.IConfig.ShouldSendHook(notify)
 }
 
 func NewGroupConcernConfig(g concern.IConfig) *GroupConcernConfig {

--- a/lsp/twitch/notify.go
+++ b/lsp/twitch/notify.go
@@ -22,6 +22,7 @@ type LiveEvent struct {
 	ViewerCount     int
 	ThumbnailURL    string
 	ProfileImageURL string
+	OfflineImageURL string
 
 	// 内部状态
 	titleChanged      bool

--- a/lsp/twitch/notify.go
+++ b/lsp/twitch/notify.go
@@ -1,12 +1,9 @@
 package twitch
 
 import (
-	"fmt"
-
 	"github.com/cnxysoft/DDBOT-WSa/lsp/concern_type"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/mmsg"
-	"github.com/cnxysoft/DDBOT-WSa/proxy_pool"
-	"github.com/cnxysoft/DDBOT-WSa/requests"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/template"
 	localutils "github.com/cnxysoft/DDBOT-WSa/utils"
 	"github.com/sirupsen/logrus"
 )
@@ -68,6 +65,28 @@ func (e *LiveEvent) Logger() *logrus.Entry {
 	})
 }
 
+// GetMSG 生成 Twitch 通知消息
+func (e *LiveEvent) GetMSG() *mmsg.MSG {
+	var data = map[string]interface{}{
+		"login":            e.Login,
+		"name":             e.Name,
+		"living":           e.Living(),
+		"title":            e.Title,
+		"game_name":        e.GameName,
+		"viewer_count":     e.ViewerCount,
+		"thumbnail":        e.ThumbnailURL,
+		"profile_image":    e.ProfileImageURL,
+		"offline_image":    e.OfflineImageURL,
+		"title_changed":    e.titleChanged,
+		"live_changed":     e.liveStatusChanged,
+	}
+	msg, err := template.LoadAndExec("notify.group.twitch.live.tmpl", data)
+	if err != nil {
+		logger.Errorf("twitch: LiveEvent LoadAndExec error %v", err)
+	}
+	return msg
+}
+
 // LiveNotify 表示需要推送到群的直播通知
 type LiveNotify struct {
 	groupCode int64
@@ -80,34 +99,7 @@ func (n *LiveNotify) GetGroupCode() int64 {
 
 func (n *LiveNotify) ToMessage() *mmsg.MSG {
 	n.Logger().Trace("正在构建 Twitch 推送消息")
-
-	if !n.Live {
-		n.Logger().Trace("构建下播通知消息")
-		return mmsg.NewTextf("%v 的 Twitch 直播已结束。", n.Name)
-	}
-
-	msg := mmsg.NewTextf("%v 正在 Twitch 直播", n.Name)
-
-	if n.Title != "" {
-		msg.Textf("\n标题: %v", n.Title)
-	}
-
-	if n.GameName != "" {
-		msg.Textf("\n游戏: %v", n.GameName)
-	}
-
-	if n.ViewerCount > 0 {
-		msg.Textf("\n观看人数: %v", n.ViewerCount)
-	}
-
-	msg.Textf("\n直播间: %v", fmt.Sprintf("https://www.twitch.tv/%v", n.Login))
-
-	if n.ThumbnailURL != "" {
-		thumbURL := FormatThumbnailURL(n.ThumbnailURL, 1280, 720)
-		msg.ImageByUrl(thumbURL, "\n[直播封面获取失败]", requests.ProxyOption(proxy_pool.PreferOversea))
-	}
-
-	return msg
+	return n.LiveEvent.GetMSG()
 }
 
 func (n *LiveNotify) Logger() *logrus.Entry {

--- a/lsp/twitch/notify.go
+++ b/lsp/twitch/notify.go
@@ -1,7 +1,6 @@
 package twitch
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cnxysoft/DDBOT-WSa/lsp/concern_type"
@@ -10,10 +9,6 @@ import (
 	"github.com/cnxysoft/DDBOT-WSa/requests"
 	localutils "github.com/cnxysoft/DDBOT-WSa/utils"
 	"github.com/sirupsen/logrus"
-)
-
-var (
-	ErrUserNotFound = errors.New("twitch 用户不存在")
 )
 
 // LiveEvent 表示一次直播状态变更事件
@@ -27,6 +22,10 @@ type LiveEvent struct {
 	ViewerCount     int
 	ThumbnailURL    string
 	ProfileImageURL string
+
+	// 内部状态
+	titleChanged      bool
+	liveStatusChanged bool
 }
 
 func (e *LiveEvent) Site() string {
@@ -39,6 +38,24 @@ func (e *LiveEvent) Type() concern_type.Type {
 
 func (e *LiveEvent) GetUid() interface{} {
 	return e.Id
+}
+
+// NotifyLiveExt 接口实现
+
+func (e *LiveEvent) IsLive() bool {
+	return true
+}
+
+func (e *LiveEvent) Living() bool {
+	return e.Live
+}
+
+func (e *LiveEvent) TitleChanged() bool {
+	return e.titleChanged
+}
+
+func (e *LiveEvent) LiveStatusChanged() bool {
+	return e.liveStatusChanged
 }
 
 func (e *LiveEvent) Logger() *logrus.Entry {

--- a/lsp/twitch/notify.go
+++ b/lsp/twitch/notify.go
@@ -1,0 +1,97 @@
+package twitch
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cnxysoft/DDBOT-WSa/lsp/concern_type"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/mmsg"
+	"github.com/cnxysoft/DDBOT-WSa/proxy_pool"
+	"github.com/cnxysoft/DDBOT-WSa/requests"
+	localutils "github.com/cnxysoft/DDBOT-WSa/utils"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrUserNotFound = errors.New("twitch 用户不存在")
+)
+
+// LiveEvent 表示一次直播状态变更事件
+type LiveEvent struct {
+	Id              string
+	Login           string
+	Name            string
+	Live            bool
+	Title           string
+	GameName        string
+	ViewerCount     int
+	ThumbnailURL    string
+	ProfileImageURL string
+}
+
+func (e *LiveEvent) Site() string {
+	return Site
+}
+
+func (e *LiveEvent) Type() concern_type.Type {
+	return Live
+}
+
+func (e *LiveEvent) GetUid() interface{} {
+	return e.Id
+}
+
+func (e *LiveEvent) Logger() *logrus.Entry {
+	return logger.WithFields(logrus.Fields{
+		"Id":    e.Id,
+		"Login": e.Login,
+		"Name":  e.Name,
+		"Live":  e.Live,
+	})
+}
+
+// LiveNotify 表示需要推送到群的直播通知
+type LiveNotify struct {
+	groupCode int64
+	LiveEvent
+}
+
+func (n *LiveNotify) GetGroupCode() int64 {
+	return n.groupCode
+}
+
+func (n *LiveNotify) ToMessage() *mmsg.MSG {
+	n.Logger().Trace("正在构建 Twitch 推送消息")
+
+	if !n.Live {
+		n.Logger().Trace("构建下播通知消息")
+		return mmsg.NewTextf("%v 的 Twitch 直播已结束。", n.Name)
+	}
+
+	msg := mmsg.NewTextf("%v 正在 Twitch 直播", n.Name)
+
+	if n.Title != "" {
+		msg.Textf("\n标题: %v", n.Title)
+	}
+
+	if n.GameName != "" {
+		msg.Textf("\n游戏: %v", n.GameName)
+	}
+
+	if n.ViewerCount > 0 {
+		msg.Textf("\n观看人数: %v", n.ViewerCount)
+	}
+
+	msg.Textf("\n直播间: %v", fmt.Sprintf("https://www.twitch.tv/%v", n.Login))
+
+	if n.ThumbnailURL != "" {
+		thumbURL := FormatThumbnailURL(n.ThumbnailURL, 1280, 720)
+		msg.ImageByUrl(thumbURL, "\n[直播封面获取失败]", requests.ProxyOption(proxy_pool.PreferOversea))
+	}
+
+	return msg
+}
+
+func (n *LiveNotify) Logger() *logrus.Entry {
+	return n.LiveEvent.Logger().WithFields(localutils.GroupLogFields(n.groupCode))
+}

--- a/lsp/twitch/notify.go
+++ b/lsp/twitch/notify.go
@@ -74,7 +74,7 @@ func (e *LiveEvent) GetMSG() *mmsg.MSG {
 		"title":            e.Title,
 		"game_name":        e.GameName,
 		"viewer_count":     e.ViewerCount,
-		"thumbnail":        e.ThumbnailURL,
+		"thumbnail":        FormatThumbnailURL(e.ThumbnailURL, 1280, 720),
 		"profile_image":    e.ProfileImageURL,
 		"offline_image":    e.OfflineImageURL,
 		"title_changed":    e.titleChanged,

--- a/lsp/twitch/twitch_test.go
+++ b/lsp/twitch/twitch_test.go
@@ -1,0 +1,61 @@
+package twitch
+
+import (
+	"testing"
+
+	"github.com/cnxysoft/DDBOT-WSa/internal/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func initConcern(t *testing.T) *TwitchConcern {
+	c := NewConcern(nil)
+	assert.NotNil(t, c)
+	c.StateManager.FreshIndex(test.G1, test.G2)
+	return c
+}
+
+func TestNewConcern(t *testing.T) {
+	test.InitBuntdb(t)
+	defer test.CloseBuntdb(t)
+
+	c := initConcern(t)
+	assert.NotNil(t, c.GetStateManager())
+	c.Stop()
+}
+
+func TestParseId(t *testing.T) {
+	test.InitBuntdb(t)
+	defer test.CloseBuntdb(t)
+
+	c := initConcern(t)
+	defer c.Stop()
+
+	id, err := c.ParseId("testuser")
+	assert.Nil(t, err)
+	assert.EqualValues(t, "testuser", id)
+
+	id, err = c.ParseId("")
+	assert.NotNil(t, err)
+}
+
+func TestSite(t *testing.T) {
+	test.InitBuntdb(t)
+	defer test.CloseBuntdb(t)
+
+	c := initConcern(t)
+	defer c.Stop()
+
+	assert.EqualValues(t, "twitch", c.Site())
+}
+
+func TestTypes(t *testing.T) {
+	test.InitBuntdb(t)
+	defer test.CloseBuntdb(t)
+
+	c := initConcern(t)
+	defer c.Stop()
+
+	types := c.Types()
+	assert.Len(t, types, 1)
+	assert.Equal(t, Live, types[0])
+}


### PR DESCRIPTION
实现 Twitch 平台的 Concern 模块，支持订阅 Twitch 频道直播状态推送。

- 新增 lsp/twitch 模块 (api/concern/notify/config)
- 使用 Twitch Helix API + OAuth2 Client Credentials 认证
- 支持 EmitQueue 轮询检测直播状态变更
- 通过 proxy_pool 支持海外代理访问
- 在 cmd/main.go 和 bot.go 中注册模块
- 在 application.yaml 示例配置中添加 twitch 配置项