### PR TITLE
补充TG的重新订阅功能，新增weibo:mode:login的autorefresh用于做api模式不可用时的备用方法

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -262,19 +262,21 @@ weibo:
   onlyOnlineNotify: true  # 是否不推送 Bot 离线期间的动态和直播，默认为 false 表示需要推送，设置为 true 表示不推送
   mode: guest             # weibo 运行模式，可选 guest / login / api
                           # guest: 访客模式，自动生成临时 Cookie
-                          # login: 登录模式，需要配置 sub 或启用 qrlogin 扫码登录
-                          # api: API 模式，从外部 API 自动获取 Cookie（推荐）
+                          # login: 登录模式，需要配置 sub 或启用 qrlogin/autorefresh
+                          # api: API 模式，从外部 API 自动获取 Cookie（推荐，但当出现api获取到的sub无法使用时请尝试使用login模式并开启autorefresh）
   interval: 30s           # weibo 访客模式下 Cookie 刷新间隔
-  sub: # 登录 weibo.com 后取得对应名称的 Cookie 填入此处（mode: login 时需要）。
+  sub: # 登录 weibo.com 后取得对应名称的 Cookie 填入此处（mode: login 时可选）。
   qrlogin: true           # 是否启用二维码登录（Cookies 失效时重启后可再次登录，仅 mode: login 时有效）
-  autorefresh: false      # 是否启用 SUB 自动刷新（仅 mode: login 时有效）
-                          # 启用后：1) 启动时若 sub 为空则从 API 获取（仅内存使用）
+  autorefresh: false      # 是否启用 SUB 自动刷新（mode: login/api 时有效）
+                          # 启用后：1) 启动时若 sub 为空则从 API 获取初始化（仅内存）
                           #      2) 每小时检查 SUB 是否变化，不同则自动替换（仅内存）
-                          #      3) 需要配合 cookieRefreshAPI 使用
-                          # 注意：不会修改配置文件中的 weibo.sub
+                          #      3) 只使用 SUB + XSRF-TOKEN，丢弃其他可能无效的字段
+                          #      4) 需要配合 cookieRefreshAPI 使用
+                          # 注意：不会修改配置文件中的 weibo.sub，每次重启重新获取
   
-  # API 模式配置（当 mode: api 时使用）
+  # API 模式配置（mode: api 或 mode: login + autorefresh 时使用）
   # 从外部 API 自动获取 Cookie，无需手动配置 sub 或扫码登录
+  # API 返回的所有 Cookie 中只会提取 SUB 和 XSRF-TOKEN 使用
   cookieRefreshAPI: "http://127.0.0.1:5000/api/Weibo/GetWeiboCookie"  # Cookie 刷新 API 地址
 
 youtube:

--- a/bot.go
+++ b/bot.go
@@ -267,6 +267,11 @@ weibo:
   interval: 30s           # weibo 访客模式下 Cookie 刷新间隔
   sub: # 登录 weibo.com 后取得对应名称的 Cookie 填入此处（mode: login 时需要）。
   qrlogin: true           # 是否启用二维码登录（Cookies 失效时重启后可再次登录，仅 mode: login 时有效）
+  autorefresh: false      # 是否启用 SUB 自动刷新（仅 mode: login 时有效）
+                          # 启用后：1) 启动时若 sub 为空则从 API 获取（仅内存使用）
+                          #      2) 每小时检查 SUB 是否变化，不同则自动替换（仅内存）
+                          #      3) 需要配合 cookieRefreshAPI 使用
+                          # 注意：不会修改配置文件中的 weibo.sub
   
   # API 模式配置（当 mode: api 时使用）
   # 从外部 API 自动获取 Cookie，无需手动配置 sub 或扫码登录

--- a/bot/go.mod
+++ b/bot/go.mod
@@ -12,7 +12,7 @@ replace (
 require (
 	github.com/Mrs4s/MiraiGo v0.0.0-20230627090859-19e3d172596e
 	github.com/cnxysoft/DDBOT-WSa v0.0.0-20250620022611-51ba1e929e90
-	github.com/cnxysoft/DDBOT-WSa/adapter v0.0.0-00010101000000-000000000000
+	github.com/cnxysoft/DDBOT-WSa/adapter v0.0.0
 	github.com/fumiama/go-base16384 v1.7.0
 	github.com/guonaihong/gout v0.3.7
 	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible

--- a/lsp/cfg/config.go
+++ b/lsp/cfg/config.go
@@ -225,6 +225,11 @@ func GetWeiboCookieRefreshAPI() string {
 	return strings.TrimSpace(config.GlobalConfig.GetString("weibo.cookieRefreshAPI"))
 }
 
+// GetWeiboAutoRefresh 检查是否启用 SUB 自动刷新功能（仅 login 模式有效）
+func GetWeiboAutoRefresh() bool {
+	return config.GlobalConfig.GetBool("weibo.autorefresh")
+}
+
 func GetExtDbEnable() bool {
 	return config.GlobalConfig.GetBool("extDb.enable")
 }

--- a/lsp/telegram_commands.go
+++ b/lsp/telegram_commands.go
@@ -1,15 +1,18 @@
 package lsp
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/Mrs4s/MiraiGo/message"
 	"github.com/Sora233/MiraiGo-Template/config"
 	localdb "github.com/cnxysoft/DDBOT-WSa/lsp/buntdb"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/concern"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/mmsg"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/permission"
 	lsptelegram "github.com/cnxysoft/DDBOT-WSa/lsp/telegram"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/weibo"
 )
 
 // StartTelegramCommands sets up a Telegram receiving loop that parses commands
@@ -45,7 +48,7 @@ func (l *Lsp) StartTelegramCommands() {
 			lsptelegram.SendToChat(chatID, mmsg.NewText("pong"))
 			return
 		case "help":
-			lsptelegram.SendToChat(chatID, mmsg.NewText("可用命令: /whosyourdaddy /list /watch /unwatch /enable /disable /grant /config /silence /abnormal /clean /noupdate /help /ping\n说明: 在群聊中可省略 -g；站点默认 bilibili，仅在其他平台时使用 -s\n示例: /watch -s bilibili -t live 123456"))
+			lsptelegram.SendToChat(chatID, mmsg.NewText("可用命令：/whosyourdaddy /list /watch /unwatch /enable /disable /grant /config /silence /abnormal /clean /noupdate /resubscribe /help /ping\n说明：在群聊中可省略 -g；站点默认 bilibili，仅在其他平台时使用 -s\n示例：/watch -s bilibili -t live 123456\n/resubscribe -g <群号> - 一键重新订阅该群的所有微博用户"))
 			return
 		case "whosyourdaddy":
 			c := tgL.newTGContext(chatID, fromID, senderUin, 0)
@@ -363,12 +366,49 @@ func (l *Lsp) StartTelegramCommands() {
 			} else {
 				err = localdb.Set(key, "")
 				if err == nil {
-					c.TextReply("成功 - 您将不再接受更新消息")
+					c.TextReply("成功 - 您不再接受更新消息")
 				}
 			}
 			if err != nil {
 				c.TextReply("失败 - " + err.Error())
 			}
+			return
+		case "resubscribe", "重新订阅":
+			// /resubscribe -g <群号>
+			group, _, _ := parseFlags(args, defaultGroup)
+			if group == 0 {
+				lsptelegram.SendToChat(chatID, mmsg.NewText("用法：/resubscribe -g <群号>"))
+				return
+			}
+			c := tgL.newTGContext(chatID, fromID, senderUin, group)
+			// 检查权限：需要管理员权限
+			if !tgL.PermissionStateManager.RequireAny(
+				permission.AdminRoleRequireOption(senderUin),
+			) {
+				c.TextReply("权限不足")
+				return
+			}
+
+			// 调用微博 Concern 的一键重新订阅功能
+			weiboConcern, err := concern.GetConcernBySiteAndType("weibo", weibo.News)
+			if err != nil {
+				c.TextReply(fmt.Sprintf("失败 - %v", err))
+				return
+			}
+
+			wc, ok := weiboConcern.(*weibo.Concern)
+			if !ok {
+				c.TextReply("失败 - 类型转换错误")
+				return
+			}
+
+			count, err := wc.ResubscribeAll(c, group)
+			if err != nil {
+				c.TextReply(fmt.Sprintf("失败 - %v", err))
+				return
+			}
+
+			c.TextSend(fmt.Sprintf("成功 - 已重新订阅 %d 个微博用户", count))
 			return
 		default:
 			// 仅当用户使用了可识别的前缀（配置前缀或以'/'开头）时才回复未知命令，避免在群内刷屏

--- a/lsp/weibo/concern.go
+++ b/lsp/weibo/concern.go
@@ -47,10 +47,31 @@ func (c *Concern) Start() error {
 	isAPI := cfg.IsWeiboAPIMode()
 	sub := ""
 
-	// API 模式：只使用 API 获取 Cookie，不检查配置也不扫码
+	// API 模式：从 API 获取 Cookie 并存入内存
 	if isAPI {
 		logger.Info("微博运行模式：API 模式，将从外部 API 自动获取 Cookie")
-		// API 模式下 sub 保持为空，freshCookieOpt 会从 API 获取
+		apiURL := cfg.GetWeiboCookieRefreshAPI()
+		if apiURL != "" {
+			logger.Info("正在从 API 获取初始 SUB...")
+			cookies, err := FreshCookieFromAPI()
+			if err != nil {
+				logger.Errorf("从 API 获取初始 SUB 失败：%v", err)
+				logger.Warn("API 模式获取 Cookie 失败，将关闭微博推送功能。")
+				return nil
+			}
+			apiSub := ExtractSUBFromCookies(cookies)
+			if apiSub != "" {
+				sub = apiSub
+				logger.Infof("从 API 成功获取初始 SUB（仅内存使用）：%s...", sub[:min(20, len(sub))])
+			} else {
+				logger.Warn("API 未返回有效的 SUB Cookie")
+				logger.Warn("将关闭微博推送功能。")
+				return nil
+			}
+		} else {
+			logger.Warn("API 模式但未配置 cookieRefreshAPI，将关闭微博推送功能。")
+			return nil
+		}
 	} else if !isGuest {
 		// Login 模式：检查 cookie、autorefresh 或扫码登录
 		sub = GetSettingCookie()

--- a/lsp/weibo/concern.go
+++ b/lsp/weibo/concern.go
@@ -52,10 +52,33 @@ func (c *Concern) Start() error {
 		logger.Info("微博运行模式：API 模式，将从外部 API 自动获取 Cookie")
 		// API 模式下 sub 保持为空，freshCookieOpt 会从 API 获取
 	} else if !isGuest {
-		// Login 模式：检查 cookie 或扫码登录
+		// Login 模式：检查 cookie、autorefresh 或扫码登录
 		sub = GetSettingCookie()
 		if sub == "" {
-			if GetQRLoginEnable() {
+			// 如果启用了 autorefresh，尝试从 API 获取初始 SUB（仅内存使用）
+			if cfg.GetWeiboAutoRefresh() {
+				apiURL := cfg.GetWeiboCookieRefreshAPI()
+				if apiURL != "" {
+					logger.Info("检测到 weibo.sub 为空但已启用 autorefresh，尝试从 API 获取初始 SUB...")
+					cookies, err := FreshCookieFromAPI()
+					if err != nil {
+						logger.Errorf("从 API 获取初始 SUB 失败：%v", err)
+					} else {
+						apiSub := ExtractSUBFromCookies(cookies)
+						if apiSub != "" {
+							sub = apiSub
+							logger.Infof("从 API 成功获取初始 SUB（仅内存使用）：%s...", sub[:min(20, len(sub))])
+						} else {
+							logger.Warn("API 未返回有效的 SUB Cookie")
+						}
+					}
+				} else {
+					logger.Warn("weibo.autorefresh 已启用但未配置 cookieRefreshAPI")
+				}
+			}
+
+			// 如果仍然没有 SUB，尝试扫码登录
+			if sub == "" && GetQRLoginEnable() {
 				logger.Info("检测到 weibo.sub 为空，已启用 weibo.qrlogin，开始扫码登录以获取 SUB ...")
 				obtained, err := RunQRLogin(QRLoginOption{OutputDir: ".", AutoOpen: true})
 				if err != nil {
@@ -65,8 +88,11 @@ func (c *Concern) Start() error {
 				}
 				sub = obtained
 				logger.Infof("扫码登录成功，已获取 SUB。请写入 application.yaml -> weibo.sub 以便下次启动：%s", sub)
-			} else {
-				logger.Warn("微博 Cookie 未设置，将关闭微博推送功能。开启 weibo.qrlogin 可自动扫码获取。")
+			}
+
+			// 如果仍然没有 SUB，模块关闭
+			if sub == "" {
+				logger.Warn("微博 Cookie 未设置，将关闭微博推送功能。可开启 weibo.qrlogin 扫码或配置 weibo.autorefresh + cookieRefreshAPI 自动获取。")
 				return nil
 			}
 		}
@@ -77,6 +103,11 @@ func (c *Concern) Start() error {
 	// API 模式下启动自动监控
 	if isAPI {
 		StartCookieRefreshMonitor(sub)
+	}
+
+	// Login 模式下启动 SUB 自动刷新
+	if !isGuest && !isAPI {
+		StartSubAutoRefresh()
 	}
 
 	if !isGuest && !isAPI {
@@ -157,6 +188,9 @@ func (c *Concern) Stop() {
 
 	// 停止 Cookie 监控
 	StopCookieRefreshMonitor()
+
+	// 停止 SUB 自动刷新
+	StopSubAutoRefresh()
 
 	c.StateManager.Stop()
 	logger.Tracef("%v StateManager 已停止", Site)

--- a/lsp/weibo/cookie_monitor.go
+++ b/lsp/weibo/cookie_monitor.go
@@ -112,23 +112,46 @@ func refreshCookieWithAPI(sub string) {
 		return
 	}
 
-	// 应用新的 Cookie
-	var opt []requests.Option
+	// 提取 SUB 和 XSRF-TOKEN（和 login + autorefresh 模式一致）
+	var newSub string
+	var xsrfToken string
 	for _, cookie := range cookies {
-		// 保留用户配置的 SUB 值
-		if cookie.Name == "SUB" && sub != "" {
-			cookie.Value = sub
-			logger.Debug("使用配置中的 SUB 值")
+		if cookie.Name == "SUB" {
+			newSub = cookie.Value
 		}
-		opt = append(opt, requests.HttpCookieOption(cookie))
+		if cookie.Name == "XSRF-TOKEN" {
+			xsrfToken = cookie.Value
+		}
+	}
+
+	if newSub == "" {
+		logger.Error("API 未返回有效的 SUB Cookie")
+		return
+	}
+
+	// 如果传入了 sub 参数，优先使用传入的值（兼容旧逻辑）
+	if sub != "" {
+		newSub = sub
+		logger.Debug("使用传入的 SUB 值")
+	}
+
+	// 只设置 SUB 和 XSRF-TOKEN（和 login 模式一致）
+	opt := []requests.Option{
+		requests.CookieOption("SUB", newSub),
+	}
+	if xsrfToken != "" {
+		opt = append(opt, requests.CookieOption("XSRF-TOKEN", xsrfToken))
+		logger.Debugf("已加载 XSRF-TOKEN: %s...", xsrfToken[:min(10, len(xsrfToken))])
+	} else {
+		logger.Warn("API 未返回 XSRF-TOKEN，可能导致部分请求失败")
 	}
 
 	visitorCookiesOpt.Store(opt)
-	logger.Info("微博 Cookie 已成功从 API 刷新")
+	logger.Info("微博 Cookie 已成功从 API 刷新（仅 SUB + XSRF-TOKEN）")
 
 	// 刷新后验证 Cookie 是否有效
 	time.Sleep(1 * time.Second)
-	if isCookieValid(sub) {
+	if isCookieValid(newSub) {
 		logger.Info("Cookie 刷新验证成功")
 	} else {
 		logger.Warn("Cookie 刷新后验证失败，可能需要检查 API 返回的 Cookie 是否正确")

--- a/lsp/weibo/init.go
+++ b/lsp/weibo/init.go
@@ -19,13 +19,28 @@ func freshCookieOpt(sub string) {
 	var cookies []*http.Cookie
 	var err error
 
-	// API 模式：强制从 API 获取
-	if cfg.IsWeiboAPIMode() {
+	// 如果传入了有效的 sub，直接使用（API 模式和 autorefresh 都会传入）
+	if sub != "" {
+		// 只需要获取 XSRF-TOKEN，SUB 已经由调用方提供
+		localutils.Retry(3, time.Second, func() bool {
+			if isGuestMode() {
+				cookies, err = FreshCookieGuest()
+			} else {
+				cookies, err = FreshCookieLogin()
+			}
+			return err == nil
+		})
+		if err != nil {
+			logger.Errorf("FreshCookie error %v", err)
+			return
+		}
+	} else if cfg.IsWeiboAPIMode() {
+		// API 模式且未传入 sub：从 API 获取（兼容旧逻辑）
 		cookies, err = FreshCookieFromAPI()
 		if err != nil {
 			logger.Errorf("FreshCookieFromAPI error %v", err)
 			logger.Warn("API 模式获取 Cookie 失败，微博功能可能无法正常使用")
-			return // 直接返回，不执行后续逻辑
+			return
 		}
 	} else {
 		// 非 API 模式：使用原有逻辑
@@ -51,7 +66,7 @@ func freshCookieOpt(sub string) {
 	if sub != "" {
 		logger.Infof("使用传入的 SUB 参数：%s...", sub[:min(20, len(sub))])
 		subValue = sub
-		// 从 cookies 中提取 XSRF-TOKEN（login 模式下 FreshCookieLogin 会返回）
+		// 从 cookies 中提取 XSRF-TOKEN
 		for _, cookie := range cookies {
 			if cookie.Name == "XSRF-TOKEN" {
 				xsrfToken = cookie.Value
@@ -69,8 +84,8 @@ func freshCookieOpt(sub string) {
 				break
 			}
 		}
-	} else if cfg.IsWeiboAPIMode() {
-		// API 模式：从 API 返回中提取 SUB 和 XSRF-TOKEN
+	} else {
+		// 从 API 或其他方式返回的 cookies 中提取 SUB 和 XSRF-TOKEN
 		for _, cookie := range cookies {
 			if cookie.Name == "SUB" {
 				subValue = cookie.Value
@@ -80,23 +95,13 @@ func freshCookieOpt(sub string) {
 			}
 		}
 		if subValue == "" {
-			logger.Warnf("API 未返回 SUB Cookie")
+			logger.Warnf("未找到 SUB Cookie")
 			return
 		}
-		logger.Infof("使用 API 返回的 SUB：%s...", subValue[:min(20, len(subValue))])
+		logger.Infof("使用从 API 获取的 SUB：%s...", subValue[:min(20, len(subValue))])
 
 		if xsrfToken == "" {
-			logger.Warnf("API 未返回 XSRF-TOKEN Cookie，可能导致请求失败")
-		}
-	} else {
-		// 非 API 模式且无配置：使用原有逻辑生成的 Cookie
-		for _, cookie := range cookies {
-			if cookie.Name == "SUB" {
-				subValue = cookie.Value
-			}
-			if cookie.Name == "XSRF-TOKEN" {
-				xsrfToken = cookie.Value
-			}
+			logger.Warnf("未找到 XSRF-TOKEN Cookie，可能导致请求失败")
 		}
 	}
 

--- a/lsp/weibo/init.go
+++ b/lsp/weibo/init.go
@@ -45,17 +45,38 @@ func freshCookieOpt(sub string) {
 	}
 
 	var subValue string
+	var xsrfToken string
 
-	// 优先使用配置中的 SUB（如果有）
-	if configuredSub := GetSettingCookie(); configuredSub != "" {
+	// 优先使用传入的 sub 参数（如果有效）
+	if sub != "" {
+		logger.Infof("使用传入的 SUB 参数：%s...", sub[:min(20, len(sub))])
+		subValue = sub
+		// 从 cookies 中提取 XSRF-TOKEN（login 模式下 FreshCookieLogin 会返回）
+		for _, cookie := range cookies {
+			if cookie.Name == "XSRF-TOKEN" {
+				xsrfToken = cookie.Value
+				break
+			}
+		}
+	} else if configuredSub := GetSettingCookie(); configuredSub != "" {
+		// 其次使用配置中的 SUB
 		logger.Infof("使用配置中的 SUB")
 		subValue = configuredSub
+		// 从 cookies 中提取 XSRF-TOKEN
+		for _, cookie := range cookies {
+			if cookie.Name == "XSRF-TOKEN" {
+				xsrfToken = cookie.Value
+				break
+			}
+		}
 	} else if cfg.IsWeiboAPIMode() {
-		// API 模式：从 API 返回中提取 SUB
+		// API 模式：从 API 返回中提取 SUB 和 XSRF-TOKEN
 		for _, cookie := range cookies {
 			if cookie.Name == "SUB" {
 				subValue = cookie.Value
-				break
+			}
+			if cookie.Name == "XSRF-TOKEN" {
+				xsrfToken = cookie.Value
 			}
 		}
 		if subValue == "" {
@@ -64,15 +85,7 @@ func freshCookieOpt(sub string) {
 		}
 		logger.Infof("使用 API 返回的 SUB：%s...", subValue[:min(20, len(subValue))])
 
-		// 检查是否有 XSRF-TOKEN
-		var hasXsrf bool
-		for _, cookie := range cookies {
-			if cookie.Name == "XSRF-TOKEN" {
-				hasXsrf = true
-				break
-			}
-		}
-		if !hasXsrf {
+		if xsrfToken == "" {
 			logger.Warnf("API 未返回 XSRF-TOKEN Cookie，可能导致请求失败")
 		}
 	} else {
@@ -80,7 +93,9 @@ func freshCookieOpt(sub string) {
 		for _, cookie := range cookies {
 			if cookie.Name == "SUB" {
 				subValue = cookie.Value
-				break
+			}
+			if cookie.Name == "XSRF-TOKEN" {
+				xsrfToken = cookie.Value
 			}
 		}
 	}
@@ -90,9 +105,15 @@ func freshCookieOpt(sub string) {
 		return
 	}
 
-	// 只设置 SUB Cookie
+	// 设置 SUB 和 XSRF-TOKEN Cookie
 	opt := []requests.Option{
 		requests.CookieOption("SUB", subValue),
+	}
+	if xsrfToken != "" {
+		opt = append(opt, requests.CookieOption("XSRF-TOKEN", xsrfToken))
+		logger.Debugf("已加载 XSRF-TOKEN: %s...", xsrfToken[:min(10, len(xsrfToken))])
+	} else {
+		logger.Warnf("未找到 XSRF-TOKEN，部分 API 请求可能失败")
 	}
 	visitorCookiesOpt.Store(opt)
 	logger.Infof("微博 SUB Cookie 已加载：%s...", subValue[:min(20, len(subValue))])

--- a/lsp/weibo/sub_autorefresh.go
+++ b/lsp/weibo/sub_autorefresh.go
@@ -1,0 +1,136 @@
+package weibo
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/cnxysoft/DDBOT-WSa/lsp/cfg"
+	"github.com/cnxysoft/DDBOT-WSa/requests"
+)
+
+var (
+	// ErrNoSUBInResponse API 响应中未包含 SUB
+	ErrNoSUBInResponse = errors.New("API 响应中未找到 SUB Cookie")
+)
+
+var (
+	// subAutoRefreshCtx 用于控制 SUB 自动刷新协程的生命周期
+	subAutoRefreshCtx    context.Context
+	subAutoRefreshCancel context.CancelFunc
+)
+
+// StartSubAutoRefresh 启动 SUB 自动刷新监控（仅 login 模式有效）
+func StartSubAutoRefresh() {
+	// 仅在 login 模式下启用
+	mode := cfg.GetWeiboMode()
+	if mode != "login" {
+		logger.Debug("非 login 模式，不启动 SUB 自动刷新")
+		return
+	}
+
+	// 检查是否启用自动刷新
+	if !cfg.GetWeiboAutoRefresh() {
+		logger.Debug("weibo.autorefresh 未启用")
+		return
+	}
+
+	apiURL := cfg.GetWeiboCookieRefreshAPI()
+	if apiURL == "" {
+		logger.Warn("微博 Cookie 刷新 API 地址未配置，SUB 自动刷新功能无法启动")
+		return
+	}
+
+	// 如果已有上下文，先取消
+	if subAutoRefreshCancel != nil {
+		subAutoRefreshCancel()
+	}
+
+	subAutoRefreshCtx, subAutoRefreshCancel = context.WithCancel(context.Background())
+
+	go func() {
+		logger.Info("SUB 自动刷新已启动，将每小时从 API 刷新一次")
+
+		// 初始延迟，等待系统启动完成
+		select {
+		case <-time.After(5 * time.Second):
+		case <-subAutoRefreshCtx.Done():
+			return
+		}
+
+		// 每小时刷新一次
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				logger.Debug("开始自动刷新微博 SUB")
+				if err := refreshSubFromAPI(); err != nil {
+					logger.Errorf("SUB 自动刷新失败: %v", err)
+				}
+			case <-subAutoRefreshCtx.Done():
+				logger.Info("SUB 自动刷新已停止")
+				return
+			}
+		}
+	}()
+}
+
+// StopSubAutoRefresh 停止 SUB 自动刷新
+func StopSubAutoRefresh() {
+	if subAutoRefreshCancel != nil {
+		subAutoRefreshCancel()
+		subAutoRefreshCancel = nil
+	}
+}
+
+// refreshSubFromAPI 从 API 获取新的 SUB 并更新配置
+func refreshSubFromAPI() error {
+	// 从 API 获取 Cookie
+	cookies, err := FreshCookieFromAPI()
+	if err != nil {
+		return err
+	}
+
+	// 提取 SUB
+	newSub := ExtractSUBFromCookies(cookies)
+	if newSub == "" {
+		return ErrNoSUBInResponse
+	}
+
+	// 获取当前配置的 SUB
+	currentSub := GetSettingCookie()
+
+	// 比较是否相同（如果当前为空，也视为需要更新）
+	if currentSub != "" && currentSub == newSub {
+		logger.Debug("SUB 未变化，无需更新")
+		return nil
+	}
+
+	// SUB 不同或当前为空，进行替换
+	if currentSub == "" {
+		logger.Info("当前 SUB 为空，正在从 API 初始化（仅内存使用）...")
+	} else {
+		logger.Infof("检测到 SUB 变化，正在更新（仅内存使用）...")
+		logger.Debugf("旧 SUB: %s...", maskSub(currentSub))
+	}
+	logger.Debugf("新 SUB: %s...", maskSub(newSub))
+
+	// 更新内存中的 Cookie
+	opt := []requests.Option{
+		requests.CookieOption("SUB", newSub),
+	}
+	visitorCookiesOpt.Store(opt)
+
+	logger.Info("SUB 已成功更新到内存")
+	return nil
+}
+
+// maskSub 隐藏 SUB 中间部分用于日志显示
+func maskSub(sub string) string {
+	if len(sub) <= 20 {
+		return "***"
+	}
+	return sub[:10] + "..." + sub[len(sub)-10:]
+}

--- a/lsp/weibo/sub_autorefresh_test.go
+++ b/lsp/weibo/sub_autorefresh_test.go
@@ -1,0 +1,97 @@
+package weibo
+
+import (
+	"testing"
+
+	miraiConfig "github.com/Sora233/MiraiGo-Template/config"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/cfg"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetWeiboAutoRefresh(t *testing.T) {
+	resetConfig := useTestConfigForAutoRefresh(t)
+	defer resetConfig()
+
+	// 默认应该是 false
+	assert.False(t, cfg.GetWeiboAutoRefresh())
+
+	// 设置为 true
+	miraiConfig.GlobalConfig.Set("weibo.autorefresh", true)
+	assert.True(t, cfg.GetWeiboAutoRefresh())
+
+	// 设置为 false
+	miraiConfig.GlobalConfig.Set("weibo.autorefresh", false)
+	assert.False(t, cfg.GetWeiboAutoRefresh())
+}
+
+func TestMaskSub(t *testing.T) {
+	testCases := []struct {
+		name     string
+		sub      string
+		expected string
+	}{
+		{
+			name:     "short sub",
+			sub:      "short",
+			expected: "***",
+		},
+		{
+			name:     "exact 20 chars",
+			sub:      "12345678901234567890",
+			expected: "***",
+		},
+		{
+			name:     "long sub",
+			sub:      "1234567890abcdef1234567890abcdef",
+			expected: "1234567890...7890abcdef",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := maskSub(tc.sub)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestStartSubAutoRefreshNotLoginMode(t *testing.T) {
+	resetConfig := useTestConfigForAutoRefresh(t)
+	defer resetConfig()
+
+	// 设置为 guest 模式，不应该启动
+	miraiConfig.GlobalConfig.Set("weibo.mode", "guest")
+	miraiConfig.GlobalConfig.Set("weibo.autorefresh", true)
+
+	// 调用 StartSubAutoRefresh 应该不会 panic
+	StartSubAutoRefresh()
+
+	// 清理
+	StopSubAutoRefresh()
+}
+
+func TestStartSubAutoRefreshNoAPI(t *testing.T) {
+	resetConfig := useTestConfigForAutoRefresh(t)
+	defer resetConfig()
+
+	// 设置为 login 模式，启用 autorefresh，但没有配置 API
+	miraiConfig.GlobalConfig.Set("weibo.mode", "login")
+	miraiConfig.GlobalConfig.Set("weibo.autorefresh", true)
+	miraiConfig.GlobalConfig.Set("weibo.cookieRefreshAPI", "")
+
+	// 调用 StartSubAutoRefresh 应该不会 panic
+	StartSubAutoRefresh()
+
+	// 清理
+	StopSubAutoRefresh()
+}
+
+func useTestConfigForAutoRefresh(t *testing.T) func() {
+	t.Helper()
+	original := miraiConfig.GlobalConfig
+	miraiConfig.GlobalConfig = &miraiConfig.Config{Viper: viper.New()}
+	return func() {
+		miraiConfig.GlobalConfig = original
+	}
+}


### PR DESCRIPTION
feat(lsp): 添加TG的微博一键重新订阅功能    efd68eb158cdc3238544d9d6399a2a69543f67d4

- 在 go.mod 中更新 DDBOT-WSa/adapter 依赖版本
- 导入 fmt、concern 和 weibo 包以支持新功能
- 在帮助文本中添加 /resubscribe 命令说明及其使用示例
- 修改 silence 命令的成功提示文本，移除冗余的"您"
- 修复 silence 命令中的字符串拼接格式错误
- 添加 resubscribe 命令实现微博用户批量重新订阅
- 实现微博 Concern 类型转换和 ResubscribeAll 方法调用
- 验证管理员权限后执行群组微博用户重新订阅操作
- 返回重新订阅成功的用户数量统计信息

feat(weibo): 初步尝试修复部分账号从ddscreen获取到的sub无法使用问题   6bf7db53dd750ef521216b5e7cfefda10346ef26

- 在配置中新增 autorefresh 选项控制自动刷新功能
- 实现每小时从 API 检查并更新 SUB Cookie 的机制
- 添加 XSRF-TOKEN 的提取和设置支持
- 实现启动时从 API 获取初始 SUB 的功能
- 新增 SUB 自动刷新的启动和停止管理函数
- 添加相关的测试用例验证功能正确性

feat(weibo): 优化微博登录模式和API模式的Cookie管理   6cebec7337c5a1ad012b9e612f3009841ae59075

- 登录模式新增autorefresh功能，支持SUB自动刷新
- API模式改为只使用SUB和XSRF-TOKEN两个关键Cookie字段
- 添加从外部API获取初始Cookie的初始化流程
- 优化Cookie刷新验证机制，确保API返回的有效性
- 支持login模式配合autorefresh时从API获取初始Cookie
- 移除对配置文件中weibo.sub的修改，全部在内存中处理
- 添加更详细的日志输出用于调试Cookie获取过程