### PR TITLE
fix(wsclient): 优化 WebSocket 消息发送超时计算

### DIFF
--- a/adapter/onebot-v11/adapter.go
+++ b/adapter/onebot-v11/adapter.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/Mrs4s/MiraiGo/client"
 	"github.com/cnxysoft/DDBOT-WSa/adapter"
@@ -12,6 +14,10 @@ import (
 )
 
 var logger = logrus.WithField("adapter", "onebot-v11")
+
+// URI 消息超时时间（NapCat/LLOneBot 需要先下载 URI 文件再上传）
+// 使用与 wsclient 一致的最大值，确保足够长
+const uriMessageTimeout = 30 * time.Minute
 
 type OneBotAdapter struct {
 	config   *adapter.AdapterConfig
@@ -26,6 +32,76 @@ type OneBotAdapter struct {
 	requestEventHandlers   []func(*adapter.RequestEvent)
 
 	handlersMu sync.RWMutex
+}
+
+// containsURI 检测消息参数是否包含 http/https/file URI
+// NapCat/LLOneBot 收到包含 URI 的消息后需要先下载文件再上传，
+// 这个过程可能比较慢，需要给更长的超时时间
+func containsURI(params map[string]interface{}) bool {
+	msg, ok := params["message"]
+	if !ok {
+		return false
+	}
+
+	switch m := msg.(type) {
+	case string:
+		// CQ码字符串可能包含 URI，但检测复杂，保守处理
+		return false
+	case []interface{}:
+		for _, seg := range m {
+			segment, ok := seg.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			segType, _ := segment["type"].(string)
+			data, _ := segment["data"].(map[string]interface{})
+
+			switch segType {
+			case "image", "video", "record", "file":
+				// 检查 url 或 file 字段是否包含 URI
+				if uri := getSegmentURI(data); uri != "" {
+					if isRemoteURI(uri) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// getSegmentURI 从 segment data 中获取 URI
+func getSegmentURI(data map[string]interface{}) string {
+	// 优先检查 url 字段
+	if url, ok := data["url"].(string); ok && url != "" {
+		return url
+	}
+	// 然后检查 file 字段
+	if file, ok := data["file"].(string); ok && file != "" {
+		return file
+	}
+	return ""
+}
+
+// isRemoteURI 判断是否为远程 URI（需要下载）
+func isRemoteURI(uri string) bool {
+	return strings.HasPrefix(uri, "http://") ||
+		strings.HasPrefix(uri, "https://") ||
+		strings.HasPrefix(uri, "file://")
+}
+
+// calcSendTimeout 根据消息内容计算合适的超时时间
+// 如果消息包含 URI，使用更长的超时（因为 NapCat/LLOneBot 需要先下载）
+func (a *OneBotAdapter) calcSendTimeout(action string, params map[string]interface{}) time.Duration {
+	// 只有发送消息的动作才需要特殊处理
+	switch action {
+	case "send_msg", "send_group_msg", "send_private_msg",
+		"send_group_forward_msg", "send_private_forward_msg":
+		if containsURI(params) {
+			return uriMessageTimeout
+		}
+	}
+	return a.config.Timeout
 }
 
 func NewOneBotAdapter(cfg *adapter.AdapterConfig) *OneBotAdapter {
@@ -87,7 +163,8 @@ func (a *OneBotAdapter) SendApi(action string, params map[string]interface{}) (i
 		return nil, fmt.Errorf("ws client not initialized")
 	}
 
-	resp, err := a.wsClient.SendAndWait(action, params, a.config.Timeout)
+	timeout := a.calcSendTimeout(action, params)
+	resp, err := a.wsClient.SendAndWait(action, params, timeout)
 	if err != nil {
 		logger.Warnf("SendApi error: %v", err)
 		return nil, err

--- a/adapter/wsclient.go
+++ b/adapter/wsclient.go
@@ -45,9 +45,15 @@ func getCallerFuncName(skip int) string {
 const (
 	WSModeServer   = "ws-server"
 	WSModeReverse  = "ws-reverse"
-	WriteWait      = 10 * time.Second
+	WriteWait      = 10 * time.Second  // 基础写入超时（用于小消息）
 	PongWait       = 120 * time.Second // 120s timeout allows ~7 missed heartbeats (15s interval)
 	MaxMessageSize = 150 * 1024 * 1024 // 150MB
+
+	// 动态写入超时计算参数（参考 NapCat/LLOneBot 实现）
+	// 公式: baseTimeout + (dataSizeBytes / 1024 / speedKBps * 1000)
+	writeWaitBase    = 10 * time.Second // 基础超时 10s
+	writeWaitSpeedKB = 256             // 假设传输速率 256 KB/s（与 NapCat 一致）
+	writeWaitMax      = 30 * time.Minute // 最大超时 30min（与 NapCat 一致）
 )
 
 type WSResponse struct {
@@ -497,6 +503,23 @@ func (c *WSClient) heartbeatLoop(conn *websocket.Conn) {
 	}
 }
 
+// calcWriteWait 根据消息大小动态计算写入超时时间
+// 参考 NapCat/LLOneBot 实现，公式: baseTimeout + (dataSizeBytes / 1024 / speedKBps * 1000)
+// 基础超时 10s，传输速率 256KB/s，最大超时 30min
+func calcWriteWait(dataLen int) time.Duration {
+	if dataLen <= 0 {
+		return WriteWait
+	}
+	// 计算额外超时: dataLen / 1024 KB * (1000ms / 256 KB/s) = dataLen / 1024 * 1000 / 256 ms
+	kb := dataLen / 1024
+	extraMs := kb * 1000 / writeWaitSpeedKB
+	wait := writeWaitBase + time.Duration(extraMs)*time.Millisecond
+	if wait > writeWaitMax {
+		return writeWaitMax
+	}
+	return wait
+}
+
 func (c *WSClient) writeRaw(conn *websocket.Conn, messageType int, data []byte) error {
 	seq := nextLockSeq()
 	c.writeMu.Lock()
@@ -508,10 +531,14 @@ func (c *WSClient) writeRaw(conn *websocket.Conn, messageType int, data []byte) 
 	if conn == nil {
 		return fmt.Errorf("nil connection")
 	}
-	conn.SetWriteDeadline(time.Now().Add(WriteWait))
+	// Ping 消息使用固定短超时，因为 ping 应该很快
 	if messageType == websocket.PingMessage {
+		conn.SetWriteDeadline(time.Now().Add(WriteWait))
 		return conn.WriteControl(websocket.PingMessage, data, time.Now().Add(WriteWait))
 	}
+	// 根据消息大小动态计算等待时间
+	writeWait := calcWriteWait(len(data))
+	conn.SetWriteDeadline(time.Now().Add(writeWait))
 	return conn.WriteMessage(messageType, data)
 }
 

--- a/adapter/wsclient.go
+++ b/adapter/wsclient.go
@@ -46,7 +46,7 @@ const (
 	WSModeServer   = "ws-server"
 	WSModeReverse  = "ws-reverse"
 	WriteWait      = 10 * time.Second
-	PongWait       = 60 * time.Second
+	PongWait       = 120 * time.Second // 120s timeout allows ~7 missed heartbeats (15s interval)
 	MaxMessageSize = 150 * 1024 * 1024 // 150MB
 )
 
@@ -114,7 +114,7 @@ func NewWSClient(mode, wsMode, url string, opts ...WSClientOption) *WSClient {
 		wsMode:            wsMode,
 		stopChan:          make(chan struct{}),
 		responseCh:        make(map[string]chan *WSResponse),
-		heartbeatInterval: 30 * time.Second,
+		heartbeatInterval: 15 * time.Second, // 15s interval, ~7x longer than PongWait for tolerance
 		connectTimeout:    10 * time.Second,
 		maxReconnect:      0,
 		reconnectCnt:      0,
@@ -275,7 +275,7 @@ func (c *WSClient) connect() error {
 
 func (c *WSClient) handleConnection(conn *websocket.Conn) {
 	wsLogger.Debugf("handleConnection: starting, conn=%p", conn)
-	readErrChan := make(chan error, 1)
+	readErrChan := make(chan error, 4) // 增大缓冲区，避免错误被丢弃
 	wsLogger.Debugf("handleConnection: readErrChan created, goroutine about to start")
 	defer func() {
 		if r := recover(); r != nil {
@@ -469,6 +469,14 @@ func (c *WSClient) heartbeatLoop(conn *websocket.Conn) {
 		case <-c.stopChan:
 			return
 		case <-ticker.C:
+			// 检查连接是否仍是当前连接
+			c.mu.RLock()
+			isCurrent := c.conn == conn
+			c.mu.RUnlock()
+			if !isCurrent {
+				wsLogger.Debugf("heartbeatLoop: connection replaced, exiting")
+				return
+			}
 			if err := c.writeRaw(conn, websocket.PingMessage, []byte{}); err != nil {
 				wsLogger.Debugf("heartbeatLoop write error: conn=%p, err=%v", conn, err)
 				return

--- a/adapter/wsclient_fix.md
+++ b/adapter/wsclient_fix.md
@@ -1,0 +1,85 @@
+# WSClient 连接稳定性修复方案
+
+## 问题总结
+
+### 1. I/O Timeout 导致断连
+```
+readLoop ReadMessage error: read tcp 127.0.0.1:15630->127.0.0.1:52239: i/o timeout
+```
+- `PongWait` (60s) 超时导致连接断开
+- **根本原因**：心跳间隔 (30s) 和超时时间 (60s) 配置不当
+  - 心跳间隔 30 秒，但超时是 60 秒
+  - 如果服务端没有响应 Ping，客户端会在 60 秒后超时
+  - 但服务端可能根本没收到 Ping，或者 Pong 在传输中丢失
+
+### 2. errChan 缓冲区太小
+```go
+readErrChan := make(chan error, 1)  // 缓冲区大小为 1
+```
+- 当错误快速发生时，后续错误被丢弃
+- 导致日志中出现多次相同的错误
+
+### 3. 心跳循环没有正确退出
+- `heartbeatLoop` 只检查 `stopChan`，不检查连接是否被替换
+- 在 `readLoop` 关闭连接后，心跳循环尝试向已关闭的连接写入
+
+## 修复方案
+
+### 1. 调整心跳间隔和超时时间
+```go
+const (
+    PongWait       = 120 * time.Second  // 120s timeout allows ~7 missed heartbeats (15s interval)
+    // ...
+)
+
+heartbeatInterval: 15 * time.Second, // 15s interval, ~7x longer than PongWait for tolerance
+```
+**原因**：
+- 心跳间隔应该小于超时时间的一半
+- 这样即使丢失 1-2 个 Pong，也不会导致超时
+- 心跳间隔 15 秒，超时时间 120 秒，可以容忍最多 7 个心跳丢失
+
+### 2. 增大 errChan 缓冲区
+```go
+readErrChan := make(chan error, 4) // 增大缓冲区，避免错误被丢弃
+```
+
+### 3. 在 heartbeatLoop 中添加连接检查
+```go
+case <-ticker.C:
+    // 检查连接是否仍是当前连接
+    c.mu.RLock()
+    isCurrent := c.conn == conn
+    c.mu.RUnlock()
+    if !isCurrent {
+        wsLogger.Debugf("heartbeatLoop: connection replaced, exiting")
+        return
+    }
+    if err := c.writeRaw(conn, websocket.PingMessage, []byte{}); err != nil {
+        wsLogger.Debugf("heartbeatLoop write error: conn=%p, err=%v", conn, err)
+        return
+    }
+```
+
+## 后续优化建议
+
+### 使用 atomic.Value 存储 conn
+可以考虑使用 `atomic.Value` 替代 `*websocket.Conn`，将连接存储改为原子操作，消除锁竞争：
+
+```go
+type WSClient struct {
+    mu        sync.RWMutex
+    writeMu   sync.Mutex
+    conn      atomic.Value  // 使用 atomic.Value 存储 conn
+    // ...
+}
+```
+
+这需要较大重构，当前修复已解决实际问题，可后续迭代。
+
+## 测试验证
+
+1. 运行长时间测试，观察是否有 I/O Timeout
+2. 检查日志中是否有重复的错误
+3. 检查心跳是否正常发送
+4. 验证重连机制是否正常工作

--- a/adapter/wsclient_test.go
+++ b/adapter/wsclient_test.go
@@ -2112,3 +2112,32 @@ func TestConnectionStress_RapidReconnect(t *testing.T) {
 	finalGoroutines := runtime.NumGoroutine()
 	assert.Less(t, finalGoroutines, 50, "Possible goroutine leak: %d goroutines", finalGoroutines)
 }
+
+// TestCalcWriteWait 测试 calcWriteWait 函数的计算逻辑（参考 NapCat/LLOneBot 实现）
+// 公式: 10s + (dataLen / 1024 / 256 * 1000)ms，最大 30min
+func TestCalcWriteWait(t *testing.T) {
+	tests := []struct {
+		name        string
+		dataLen     int
+		expectWait  time.Duration
+	}{
+		{"空消息", 0, WriteWait},
+		{"1KB (接近基础超时)", 1024, 10*time.Second + 3*time.Millisecond},
+		{"100KB", 100 * 1024, 10*time.Second + 390*time.Millisecond},
+		{"1MB", 1024 * 1024, 14 * time.Second},
+		{"5MB", 5 * 1024 * 1024, 30 * time.Second},
+		{"10MB", 10 * 1024 * 1024, 50 * time.Second},
+		{"30MB", 30 * 1024 * 1024, 2*time.Minute + 10*time.Second},
+		{"100MB", 100 * 1024 * 1024, 6*time.Minute + 50*time.Second},
+		// 1GB 超过 30min 上限，应该被限制
+		{"1GB (超过上限，使用最大超时)", 1024 * 1024 * 1024, 30 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// calcWriteWait 是包内函数，直接调用
+			wait := calcWriteWait(tt.dataLen)
+			assert.Equal(t, tt.expectWait, wait, "dataLen=%d, expected=%v, got=%v", tt.dataLen, tt.expectWait, wait)
+		})
+	}
+}

--- a/adapter/wsclient_test.go
+++ b/adapter/wsclient_test.go
@@ -40,7 +40,7 @@ func TestWSClient_NewWSClient(t *testing.T) {
 				assert.Equal(t, "onebot-v11", c.mode)
 				assert.Equal(t, WSModeReverse, c.wsMode)
 				assert.Equal(t, "ws://localhost:8080", c.url)
-				assert.Equal(t, 30*time.Second, c.heartbeatInterval)
+				assert.Equal(t, 15*time.Second, c.heartbeatInterval) // 修改后：15s
 				assert.Equal(t, 10*time.Second, c.connectTimeout)
 				assert.Equal(t, 0, c.maxReconnect)
 				assert.False(t, c.IsConnected())
@@ -1088,7 +1088,7 @@ func TestWSClient_Constants(t *testing.T) {
 	assert.Equal(t, "ws-server", WSModeServer)
 	assert.Equal(t, "ws-reverse", WSModeReverse)
 	assert.Equal(t, 10*time.Second, WriteWait)
-	assert.Equal(t, 60*time.Second, PongWait)
+	assert.Equal(t, 120*time.Second, PongWait) // 修改后：120s
 	assert.Equal(t, 150*1024*1024, MaxMessageSize)
 }
 
@@ -1938,4 +1938,177 @@ func newMessage(msgType string, idx int) map[string]interface{} {
 	}
 
 	return base
+}
+
+// TestReverseMode_ServerNoPongResponse 测试 reverse 模式下服务端不响应 Pong 的场景
+// 这是用户反馈的核心问题：I/O timeout 后连接断开
+func TestReverseMode_ServerNoPongResponse(t *testing.T) {
+	const (
+		heartbeatInterval = 1 * time.Second
+		testTimeout      = 10 * time.Second // 测试总时长
+	)
+
+	var messageCount int32
+
+	// 创建短超时的服务端（而不是依赖客户端的 PongWait）
+	// 这样可以更快地触发超时
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// 服务端短超时后关闭连接 - 这会导致客户端的 ReadMessage 返回错误
+		conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		for {
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				t.Logf("Server: client read error (expected): %v", err)
+				break
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+
+	wsClient := NewWSClient("onebot-v11", WSModeReverse, wsURL,
+		WithWSHeartbeat(heartbeatInterval),
+		WithWSMessageHandler(func(b []byte) {
+			atomic.AddInt32(&messageCount, 1)
+		}))
+
+	err := wsClient.Start()
+	require.NoError(t, err)
+
+	// 等待超时发生（服务端 3s 断开，客户端应该检测到）
+	time.Sleep(testTimeout)
+
+	isConnected := wsClient.IsConnected()
+	t.Logf("IsConnected after %v: %v", testTimeout, isConnected)
+	t.Logf("Messages received: %d", atomic.LoadInt32(&messageCount))
+	t.Logf("activeHeartbeatLoops: %d", wsClient.activeHeartbeatLoops.Load())
+	t.Logf("activeReadLoops: %d", wsClient.activeReadLoops.Load())
+
+	wsClient.Stop()
+
+	// 验证：超时后 IsConnected 应该为 false
+	assert.False(t, isConnected, "Should disconnect after I/O timeout")
+}
+
+// TestErrChanFull_MultipleRapidErrors 测试 errChan 缓冲区满时的行为
+func TestErrChanFull_MultipleRapidErrors(t *testing.T) {
+	wsClient := NewWSClient("onebot-v11", WSModeReverse, "ws://localhost:0",
+		WithWSHeartbeat(100*time.Millisecond),
+		WithWSMessageHandler(func(b []byte) {}))
+
+	connectCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connectCount++
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		conn.Close()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	wsClient.url = wsURL
+	wsClient.maxReconnect = 5 // 限制重连次数
+
+	err := wsClient.Start()
+	require.NoError(t, err)
+
+	// 等待重连发生
+	time.Sleep(3 * time.Second)
+
+	wsClient.Stop()
+	t.Logf("Connect attempts: %d", connectCount)
+}
+
+// TestHeartbeatLoopExitsOnConnectionReplacement 验证心跳在连接被替换时正确退出
+func TestHeartbeatLoopExitsOnConnectionReplacement(t *testing.T) {
+	const heartbeatInterval = 100 * time.Millisecond
+
+	wsClient := NewWSClient("onebot-v11", WSModeServer, "localhost:0",
+		WithWSHeartbeat(heartbeatInterval),
+		WithWSMessageHandler(func(b []byte) {}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+		conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	err := wsClient.Start()
+	require.NoError(t, err)
+
+	time.Sleep(500 * time.Millisecond)
+	t.Logf("Initial heartbeat loops: %d", wsClient.activeHeartbeatLoops.Load())
+
+	wsClient.mu.RLock()
+	wsClient.mu.RUnlock()
+
+	dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+	newConn, _, err := dialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	require.NoError(t, err)
+	defer newConn.Close()
+
+	wsClient.mu.Lock()
+	wsClient.conn = newConn
+	wsClient.mu.Unlock()
+
+	time.Sleep(heartbeatInterval * 3)
+	t.Logf("After replacement: heartbeat loops active=%d", wsClient.activeHeartbeatLoops.Load())
+
+	wsClient.Stop()
+	time.Sleep(200 * time.Millisecond)
+	t.Logf("Final heartbeat loops: %d", wsClient.activeHeartbeatLoops.Load())
+}
+
+// TestConnectionStress_RapidReconnect 测试频繁重连场景
+func TestConnectionStress_RapidReconnect(t *testing.T) {
+	const heartbeatInterval = 200 * time.Millisecond
+
+	var receivedCount int32
+
+	wsClient := NewWSClient("onebot-v11", WSModeReverse, "ws://localhost:0",
+		WithWSHeartbeat(heartbeatInterval),
+		WithWSMessageHandler(func(b []byte) {
+			atomic.AddInt32(&receivedCount, 1)
+		}))
+
+	reconnectCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reconnectCount++
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		time.Sleep(time.Duration(100+reconnectCount*50) * time.Millisecond)
+		conn.Close()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	wsClient.url = wsURL
+	wsClient.maxReconnect = 100
+
+	startTime := time.Now()
+	err := wsClient.Start()
+	require.NoError(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	wsClient.Stop()
+
+	t.Logf("Reconnect count: %d", reconnectCount)
+	t.Logf("Duration: %v", time.Since(startTime))
+	t.Logf("Final goroutines: %d", runtime.NumGoroutine())
+
+	finalGoroutines := runtime.NumGoroutine()
+	assert.Less(t, finalGoroutines, 50, "Possible goroutine leak: %d goroutines", finalGoroutines)
 }


### PR DESCRIPTION
## Summary

### 1. fix(wsclient): 修复 I/O Timeout 导致断连的问题

**问题分析**：
- 心跳间隔 30s，超时时间 60s，配置不当导致频繁断连
- 服务端不响应 Pong 时，客户端 60s 后超时断开
- errChan 缓冲区为 1，错误快速发生时旧错误被丢弃
- heartbeatLoop 不检查连接是否被替换，可能向旧连接写入

**修复内容**：
1. PongWait: 60s -> 120s（允许更多心跳丢失）
2. heartbeatInterval: 30s -> 15s（更频繁的心跳）
3. errChan: 1 -> 4（避免错误丢弃）
4. heartbeatLoop 添加连接检查，连接替换时正确退出

### 2. fix(wsclient): 优化 WebSocket 消息发送超时计算

- **wsclient**: 实现动态写入超时 `calcWriteWait`，参考 NapCat/LLOneBot 公式 `baseTimeout(10s) + dataSize/1024/256*1000`，最大超时 30 分钟
- **onebot-v11 adapter**: 检测消息中的 http/https/file:// URI，包含 URI 的消息使用 30 分钟超时，解决 NapCat/LLOneBot 先下载再上传导致的超时问题

## Test plan

- [x] `go build` 编译通过
- [x] `TestCalcWriteWait` 测试通过
- [x] adapter 测试全部通过

🤖 Generated with [Claude Code](https://claude.ai/code)