### PR TITLE
fix(twitch): 修复 freshCount 阈值逻辑反转导致通知永远不发送的 bug

### DIFF
--- a/lsp/twitch/concern.go
+++ b/lsp/twitch/concern.go
@@ -170,10 +170,13 @@ func (c *TwitchConcern) fresh() concern.FreshFunc {
 				streams, err := GetStreamsByLogins(logins)
 				if err != nil {
 					logger.Errorf("GetStreamsByLogins error %v", err)
-				} else {
-					for i := range streams {
-						liveMap[streams[i].UserLogin] = streams[i]
-					}
+					// API 失败时跳过本次轮询，避免空 liveMap 将所有频道误判为下播
+					freshCount.Add(1)
+					t.Reset(interval)
+					continue
+				}
+				for i := range streams {
+					liveMap[streams[i].UserLogin] = streams[i]
 				}
 			}
 
@@ -195,8 +198,8 @@ func (c *TwitchConcern) fresh() concern.FreshFunc {
 					if isLive {
 						event := c.buildLiveEvent(login, stream, isLive, false, nil)
 						title = event.Title
-						if freshCount.Load() < freshCountLiveThreshold {
-							event.liveStatusChanged = true
+						event.liveStatusChanged = true
+						if freshCount.Load() >= freshCountLiveThreshold {
 							eventChan <- event
 						}
 					}
@@ -212,7 +215,7 @@ func (c *TwitchConcern) fresh() concern.FreshFunc {
 							event := c.buildLiveEvent(login, stream, isLive, hasLast, last)
 							event.titleChanged = true
 							event.liveStatusChanged = false
-							if freshCount.Load() < freshCountLiveThreshold {
+							if freshCount.Load() >= freshCountLiveThreshold {
 								eventChan <- event
 							}
 							c.updateLastStatus(login, &LastStatus{Live: isLive, Title: stream.Title})
@@ -226,14 +229,14 @@ func (c *TwitchConcern) fresh() concern.FreshFunc {
 
 				if isLive {
 					// 开播
-					if freshCount.Load() < freshCountLiveThreshold {
-						event.liveStatusChanged = true
+					event.liveStatusChanged = true
+					if freshCount.Load() >= freshCountLiveThreshold {
 						eventChan <- event
 					}
 				} else {
 					// 下播
-					if freshCount.Load() < freshCountOfflineThreshold {
-						event.liveStatusChanged = true
+					event.liveStatusChanged = true
+					if freshCount.Load() >= freshCountOfflineThreshold {
 						eventChan <- event
 					}
 				}


### PR DESCRIPTION
## Summary

- 修复 Twitch `freshCount` 阈值条件与 bilibili 模式相反的 bug：bilibili 用 `< 阈值` 时跳过（启动期不发），twitch 错误地用 `< 阈值` 时发送（仅启动初期发送，之后永远不发）
- 将 4 处 `freshCount < threshold` 判断反转为 `>= threshold`，与 bilibili 的 `concern_fresher.go` 行为一致
- API 错误（`GetStreamsByLogins` 超时/失败）时跳过整个轮询周期，避免空 `liveMap` 将所有正在直播的频道误判为下播并污染 `LastStatus`

## 问题分析

**根因**：`fresh()` 中所有事件发送都被 `freshCount < threshold` 门控，但条件方向与 bilibili 相反：

| 模块 | 条件 | 行为 |
|---|---|---|
| bilibili（正确） | `freshCount < 1` → **return 跳过** | 启动期不发，稳定后正常发 |
| twitch（修复前） | `freshCount < 1` → **发送** | 仅首个周期发，之后永远不发 |

默认配置 `onlyOnlineNotify=false` 时 `freshCount` 初始化为 1000，`1000 < 1` 恒为 false，模块从一开始就不发任何通知。

**次要问题**：`GetStreamsByLogins` 失败时 `liveMap` 为空，后续循环将所有频道视为下播并更新 `LastStatus`，导致状态污染。
