### PR TITLE
feat: 新增合并转发消息(forward)和buntdb有序集合支持

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(go vet:*)",
       "Bash(go mod:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(go doc:*)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ package*.json
 # AI Agent documentation (local)
 /AGENTS.md
 /CLAUDE.md
+
+# Runtime data - DO NOT COMMIT
+/res/
+/lsp/bilibili/res/bilibili_area_list.json

--- a/.run/debug.run.xml
+++ b/.run/debug.run.xml
@@ -2,12 +2,12 @@
   <configuration default="false" name="debug" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="DDBOT-WSa" />
     <working_directory value="$PROJECT_DIR$/debug" />
-    <go_parameters value="-v -ldflags=&quot;-extldflags=-static&quot; -gcflags &quot;all=-N -l&quot; -tags cgo" />
+    <go_parameters value="-v -ldflags=&quot;-extldflags=-static&quot; -gcflags &quot;all=-N -l&quot;" />
     <parameters value="--debug" />
     <envs>
       <env name="GOARCH" value="amd64" />
       <env name="GOOS" value="windows" />
-      <env name="CGO_ENABLED" value="1" />
+      <env name="CGO_ENABLED" value="0" />
     </envs>
     <kind value="DIRECTORY" />
     <package value="github.com/cnxysoft/DDBOT-WSa" />

--- a/.run/debug.run.xml
+++ b/.run/debug.run.xml
@@ -2,12 +2,12 @@
   <configuration default="false" name="debug" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="DDBOT-WSa" />
     <working_directory value="$PROJECT_DIR$/debug" />
-    <go_parameters value="-v -ldflags=&quot;-extldflags=-static&quot; -gcflags &quot;all=-N -l&quot;" />
+    <go_parameters value="-v -ldflags=&quot;-extldflags=-static&quot; -gcflags &quot;all=-N -l&quot; -tags cgo" />
     <parameters value="--debug" />
     <envs>
       <env name="GOARCH" value="amd64" />
       <env name="GOOS" value="windows" />
-      <env name="CGO_ENABLED" value="0" />
+      <env name="CGO_ENABLED" value="1" />
     </envs>
     <kind value="DIRECTORY" />
     <package value="github.com/cnxysoft/DDBOT-WSa" />

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1277,6 +1277,64 @@ GetIgnoreExpire: Get配置，忽略key的过期时间，如果key曾经设置过
 {{ $duration := newDuration }}
 ```
 
+### 有序集合（Sorted Set）函数
+
+基于 buntdb 的有序集合，支持按分数（score）范围查询，适用于定时任务、优先级队列等场景。
+
+存储格式：`ss:{setName}:{member}`，索引类型为 `IndexFloat`，支持高效的 O(log n) 范围查询。
+
+`ZAdd` - 添加成员到有序集合
+```text
+{{ ZAdd "MySet" "member1" 100.0 }}
+{{ ZAdd "ReserveList" $key (getTime $date "unix") }}
+```
+
+| 参数 | 类型 | 说明 |
+|-----|------|-----|
+| setName | string | 有序集合名称 |
+| member | string | 成员标识 |
+| score | number/string | 分数值（支持 float64、string、int 等类型，内部自动转换） |
+
+`ZRangeByScore` - 根据分数范围获取成员
+```text
+{{ $list := ZRangeByScore "ReserveList" 0 (getTime "now" "unix") }}
+{{ range $list }}
+    {{ .member }} - {{ .score }}
+{{ end }}
+```
+
+| 参数 | 类型 | 说明 |
+|-----|------|-----|
+| setName | string | 有序集合名称 |
+| min | number/string | 最小分数（支持 string 类型，内部自动转换为 float64） |
+| max | number/string | 最大分数 |
+
+返回：`[]map[string]interface{}`，每个元素包含 `member`（成员）和 `score`（分数）字段。
+
+`ZRem` - 移除有序集合中的成员
+```text
+{{ ZRem "ReserveList" "member1" "member2" }}
+```
+
+| 参数 | 类型 | 说明 |
+|-----|------|-----|
+| setName | string | 有序集合名称 |
+| members | ...string | 要移除的成员（可变参数） |
+
+**使用示例：定时任务**
+```text
+{{- /* 获取所有已到期的预约项 */ -}}
+{{ $dueList := ZRangeByScore "ReserveList" -9223372036854775808 (getTime "now" "unix") }}
+{{ range $dueList }}
+    {{ $data := getJson .member }}
+    {{ if $data }}
+        {{ /* 发送通知 */ }}
+    {{ end }}
+    {{ ZRem "ReserveList" .member }}
+    {{ del .member }}
+{{ end }}
+```
+
 ## 当前支持的命令模板
 
 命令通用模板变量：
@@ -1810,6 +1868,48 @@ ACFUN-{{ .name }}直播结束了
   <summary>默认模板</summary>
 
 *该模板默认为空，即不发送消息*
+
+```text
+```
+
+</details>
+
+- 群消息事件（通用消息处理模板）
+
+模板名：`trigger.group.message.tmpl`
+
+**说明**：此模板会在**所有群消息**的命令执行完成后触发，适用于消息日志记录、关键字捕获、命令调用统计等场景。
+
+| 模板变量        | 类型                   | 含义                                       |
+|-------------|----------------------|------------------------------------------|
+| msg         | *message.GroupMessage | 完整的群消息对象                              |
+| group_code  | int64                | 群号码                                      |
+| group_name  | string               | 群名称                                      |
+| member_code | int64                | 发送者QQ号                                  |
+| member_name | string               | 发送者昵称                                   |
+| isCommand   | bool                 | 消息是否带有命令前缀（如`/roll`）                    |
+| isMatched   | bool                 | 命令是否匹配到了处理函数（仅当`isCommand`为true时有意义）    |
+| commandName | string               | 命令名称（无前缀），未带命令前缀时为空字符串                  |
+| raw_message | *message.GroupMessage | 完整的群消息对象（与`msg`相同）                      |
+| command     | map[string]string    | 所有命令名称的映射（便于在模板中获取命令前缀等配置）               |
+
+**使用方式**：
+
+1. 在 `template` 目录下创建 `trigger.group.message.tmpl` 文件
+2. 只要此文件存在（内容不限），就会在所有群消息处理完成后执行
+3. 文件为空时，模板不产生任何输出，不发送消息
+
+**示例用途**：
+
+- 记录所有群消息到外部系统
+- 关键字监听和自动回复
+- 命令使用统计
+- 消息日志
+
+<details>
+  <summary>默认模板</summary>
+
+*该模板默认为空，即不发送任何消息。只有当用户在 `template` 目录下创建了此文件后才会生效。*
 
 ```text
 ```

--- a/adapter/interface.go
+++ b/adapter/interface.go
@@ -237,6 +237,13 @@ type Adapter interface {
 	SetGroupAdmin(groupCode, memberUin int64, enable bool) error
 	EditGroupCard(groupCode, memberUin int64, card string) error
 	EditGroupTitle(groupCode, memberUin int64, title string) error
+
+	// SendGroupForwardMessage 发送群合并转发消息
+	// nodes 格式: []map[string]interface{}{{type: "node", data: map[string]interface{}{...}}}
+	// options 顶层参数: prompt, source, summary, news (可选)
+	SendGroupForwardMessage(groupCode int64, nodes []map[string]interface{}, options *ForwardOptions) (int32, string, error)
+	// SendPrivateForwardMessage 发送私聊合并转发消息
+	SendPrivateForwardMessage(userID int64, nodes []map[string]interface{}, options *ForwardOptions) (int32, string, error)
 }
 
 type EventCallback func(interface{})
@@ -283,6 +290,15 @@ type SenderInfo struct {
 	Nickname string
 	Card     string
 	Role     string
+}
+
+// ForwardOptions 合并转发消息的顶层参数
+// 对应 onebot-v11 send_group_forward_msg API 的顶层字段
+type ForwardOptions struct {
+	Prompt  string   // 转发消息外显标题 (LLOneBot/NapCatQQ 支持)
+	Source  string   // 转发来源 (LLOneBot/NapCatQQ 支持)
+	Summary string   // 转发摘要 (LLOneBot/NapCatQQ 支持)
+	News    []string // 转发预览文本列表 (LLOneBot/NapCatQQ 支持)
 }
 
 // ConvertToMessageElements converts []MessageSegment to []message.IMessageElement
@@ -419,4 +435,10 @@ type BotCaller interface {
 	SendApi(api string, params map[string]interface{}) (interface{}, error)
 	GroupPoke(groupCode, target int64) error
 	FriendPoke(target int64) error
+	// SendGroupForwardMessage 发送群合并转发消息
+	// nodes 格式: []map[string]interface{}{{type: "node", data: map[string]interface{}{id: "msgId"}}}
+	// options 顶层参数: prompt, source, summary, news (可选)
+	SendGroupForwardMessage(groupCode int64, nodes []map[string]interface{}, options *ForwardOptions) (int32, string, error)
+	// SendPrivateForwardMessage 发送私聊合并转发消息
+	SendPrivateForwardMessage(userID int64, nodes []map[string]interface{}, options *ForwardOptions) (int32, string, error)
 }

--- a/adapter/messenger.go
+++ b/adapter/messenger.go
@@ -251,6 +251,20 @@ func (m *Messenger) SendPrivateMessage(target int64, msg *message.SendingMessage
 	}
 }
 
+func (m *Messenger) SendGroupForwardMessage(groupCode int64, nodes []map[string]interface{}, options *ForwardOptions) (int32, string, error) {
+	if m.Adapter == nil {
+		return -1, "", fmt.Errorf("adapter not initialized")
+	}
+	return m.Adapter.SendGroupForwardMessage(groupCode, nodes, options)
+}
+
+func (m *Messenger) SendPrivateForwardMessage(userID int64, nodes []map[string]interface{}, options *ForwardOptions) (int32, string, error) {
+	if m.Adapter == nil {
+		return -1, "", fmt.Errorf("adapter not initialized")
+	}
+	return m.Adapter.SendPrivateForwardMessage(userID, nodes, options)
+}
+
 func (m *Messenger) buildMessageSegments(msg *message.SendingMessage) []MessageSegment {
 	var segments []MessageSegment
 
@@ -816,6 +830,7 @@ func (m *Messenger) handleNoticeEvent(event *NoticeEvent) {
 			GroupCode:   event.GroupID,
 			OperatorUin: event.OperatorID,
 			AuthorUin:   event.UserID,
+			MessageId:   int32(event.MessageID),
 		})
 	case "essence":
 		m.eventDispatcher.DispatchGroupEssenceChanged(&client.GroupDigestEvent{

--- a/adapter/onebot-v11/adapter.go
+++ b/adapter/onebot-v11/adapter.go
@@ -209,6 +209,102 @@ func (a *OneBotAdapter) SendPrivateMessage(userID int64, message interface{}) (i
 	return 0, nil
 }
 
+func (a *OneBotAdapter) SendGroupForwardMessage(groupCode int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	params := map[string]interface{}{
+		"group_id": groupCode,
+		"messages": nodes,
+	}
+
+	// 添加顶层参数 (prompt, source, summary, news)
+	if options != nil {
+		if options.Prompt != "" {
+			params["prompt"] = options.Prompt
+		}
+		if options.Source != "" {
+			params["source"] = options.Source
+		}
+		if options.Summary != "" {
+			params["summary"] = options.Summary
+		}
+		if len(options.News) > 0 {
+			news := make([]map[string]string, 0, len(options.News))
+			for _, n := range options.News {
+				news = append(news, map[string]string{"text": n})
+			}
+			params["news"] = news
+		}
+	}
+
+	data, err := a.SendApi("send_group_forward_msg", params)
+	if err != nil {
+		return 0, "", err
+	}
+
+	if dataMap, ok := data.(map[string]interface{}); ok {
+		if msgID, ok := dataMap["message_id"].(float64); ok {
+			var forwardID string
+			// 优先使用 forward_id (LLOneBot)
+			if fid, ok := dataMap["forward_id"].(string); ok {
+				forwardID = fid
+			} else if resid, ok := dataMap["res_id"].(string); ok {
+				// fallback 到 res_id (NapCatQQ)
+				forwardID = resid
+			}
+			return int32(msgID), forwardID, nil
+		}
+	}
+
+	return 0, "", nil
+}
+
+func (a *OneBotAdapter) SendPrivateForwardMessage(userID int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	params := map[string]interface{}{
+		"user_id": userID,
+		"messages": nodes,
+	}
+
+	// 添加顶层参数 (prompt, source, summary, news)
+	if options != nil {
+		if options.Prompt != "" {
+			params["prompt"] = options.Prompt
+		}
+		if options.Source != "" {
+			params["source"] = options.Source
+		}
+		if options.Summary != "" {
+			params["summary"] = options.Summary
+		}
+		if len(options.News) > 0 {
+			news := make([]map[string]string, 0, len(options.News))
+			for _, n := range options.News {
+				news = append(news, map[string]string{"text": n})
+			}
+			params["news"] = news
+		}
+	}
+
+	data, err := a.SendApi("send_private_forward_msg", params)
+	if err != nil {
+		return 0, "", err
+	}
+
+	if dataMap, ok := data.(map[string]interface{}); ok {
+		if msgID, ok := dataMap["message_id"].(float64); ok {
+			var forwardID string
+			// 优先使用 forward_id (LLOneBot)
+			if fid, ok := dataMap["forward_id"].(string); ok {
+				forwardID = fid
+			} else if resid, ok := dataMap["res_id"].(string); ok {
+				// fallback 到 res_id (NapCatQQ)
+				forwardID = resid
+			}
+			return int32(msgID), forwardID, nil
+		}
+	}
+
+	return 0, "", nil
+}
+
 func (a *OneBotAdapter) OnGroupMessage(handler func(*adapter.GroupMessageEvent)) {
 	a.handlersMu.Lock()
 	defer a.handlersMu.Unlock()

--- a/adapter/satori/adapter.go
+++ b/adapter/satori/adapter.go
@@ -315,10 +315,25 @@ func (a *SatoriAdapter) SendGroupForwardMessage(groupCode int64, nodes []map[str
 	}
 
 	content := a.renderForwardContent(nodes)
-	data, err := a.SendApi("message.create", map[string]interface{}{
+	params := map[string]interface{}{
 		"channel_id": channelID,
 		"content":    content,
-	})
+	}
+
+	// 添加转发选项 (prompt, source, summary)
+	if options != nil {
+		if options.Prompt != "" {
+			params["prompt"] = options.Prompt
+		}
+		if options.Source != "" {
+			params["source"] = options.Source
+		}
+		if options.Summary != "" {
+			params["summary"] = options.Summary
+		}
+	}
+
+	data, err := a.SendApi("message.create", params)
 	if err != nil {
 		logger.Warnf("Satori SendGroupForwardMessage error: %v", err)
 		return 0, "", err
@@ -342,10 +357,25 @@ func (a *SatoriAdapter) SendPrivateForwardMessage(userID int64, nodes []map[stri
 	}
 
 	content := a.renderForwardContent(nodes)
-	data, err := a.SendApi("message.create", map[string]interface{}{
+	params := map[string]interface{}{
 		"channel_id": channelID,
 		"content":    content,
-	})
+	}
+
+	// 添加转发选项 (prompt, source, summary)
+	if options != nil {
+		if options.Prompt != "" {
+			params["prompt"] = options.Prompt
+		}
+		if options.Source != "" {
+			params["source"] = options.Source
+		}
+		if options.Summary != "" {
+			params["summary"] = options.Summary
+		}
+	}
+
+	data, err := a.SendApi("message.create", params)
 	if err != nil {
 		logger.Warnf("Satori SendPrivateForwardMessage error: %v", err)
 		return 0, "", err
@@ -375,20 +405,209 @@ func (a *SatoriAdapter) renderForwardContent(nodes []map[string]interface{}) str
 			continue
 		}
 		if nodeType == "node" {
-			// Render each node as a message
+			// Extract sender info for <author> element
+			senderName := extractString(data["name"])
+			senderId := extractString(data["uin"])
+
 			if id, ok := data["id"].(string); ok {
 				// Reference to existing message
+				if senderName != "" || senderId != "" {
+					builder.WriteString(`<author`)
+					if senderName != "" {
+						builder.WriteString(` name="`)
+						builder.WriteString(htmlEscape(senderName))
+						builder.WriteString(`"`)
+					}
+					if senderId != "" {
+						builder.WriteString(` id="`)
+						builder.WriteString(htmlEscape(senderId))
+						builder.WriteString(`"`)
+					}
+					builder.WriteString(`/>`)
+				}
 				builder.WriteString(`<message id="`)
 				builder.WriteString(htmlEscape(id))
 				builder.WriteString(`" forward="true"/>`)
-			} else if content, ok := data["content"].([]interface{}); ok {
-				// Custom content - render as nested messages
+			} else if content, ok := data["content"].([]map[string]interface{}); ok {
+				// Custom content - render with author element and nested message
+				if senderName != "" || senderId != "" {
+					builder.WriteString(`<author`)
+					if senderName != "" {
+						builder.WriteString(` name="`)
+						builder.WriteString(htmlEscape(senderName))
+						builder.WriteString(`"`)
+					}
+					if senderId != "" {
+						builder.WriteString(` id="`)
+						builder.WriteString(htmlEscape(senderId))
+						builder.WriteString(`"`)
+					}
+					builder.WriteString(`/>`)
+				}
+				builder.WriteString(`<message>`)
 				for _, c := range content {
-					if cMap, ok := c.(map[string]interface{}); ok {
-						seg := adapter.MessageSegment{Type: extractString(cMap["type"]), Data: cMap}
-						builder.WriteString(a.renderMessageContent([]adapter.MessageSegment{seg}))
+					segData, _ := c["data"].(map[string]interface{})
+					seg := adapter.MessageSegment{Type: extractString(c["type"]), Data: segData}
+					builder.WriteString(a.renderMessageContent([]adapter.MessageSegment{seg}))
+				}
+				builder.WriteString(`</message>`)
+			} else if content, ok := data["content"].(string); ok && content != "" {
+				// Plain text content
+				if senderName != "" || senderId != "" {
+					builder.WriteString(`<author`)
+					if senderName != "" {
+						builder.WriteString(` name="`)
+						builder.WriteString(htmlEscape(senderName))
+						builder.WriteString(`"`)
+					}
+					if senderId != "" {
+						builder.WriteString(` id="`)
+						builder.WriteString(htmlEscape(senderId))
+						builder.WriteString(`"`)
+					}
+					builder.WriteString(`/>`)
+				}
+				builder.WriteString(`<message>`)
+				builder.WriteString(htmlEscape(content))
+				builder.WriteString(`</message>`)
+			} else if contentList, ok := data["content"].([]interface{}); ok && len(contentList) > 0 {
+				// Nested forward - content is []interface{} containing inner nodes
+				if senderName != "" || senderId != "" {
+					builder.WriteString(`<author`)
+					if senderName != "" {
+						builder.WriteString(` name="`)
+						builder.WriteString(htmlEscape(senderName))
+						builder.WriteString(`"`)
+					}
+					if senderId != "" {
+						builder.WriteString(` id="`)
+						builder.WriteString(htmlEscape(senderId))
+						builder.WriteString(`"`)
+					}
+					builder.WriteString(`/>`)
+				}
+				builder.WriteString(`<message forward="true">`)
+				for _, item := range contentList {
+					if nodeMap, ok := item.(map[string]interface{}); ok {
+						// Each item is an inner node with type and data
+						innerData, _ := nodeMap["data"].(map[string]interface{})
+						if innerData == nil {
+							continue
+						}
+						// Extract inner sender info
+						innerSenderName := extractString(innerData["name"])
+						innerSenderId := extractString(innerData["uin"])
+
+						if id, ok := innerData["id"].(string); ok {
+							// Reference to existing message
+							if innerSenderName != "" || innerSenderId != "" {
+								builder.WriteString(`<author`)
+								if innerSenderName != "" {
+									builder.WriteString(` name="`)
+									builder.WriteString(htmlEscape(innerSenderName))
+									builder.WriteString(`"`)
+								}
+								if innerSenderId != "" {
+									builder.WriteString(` id="`)
+									builder.WriteString(htmlEscape(innerSenderId))
+									builder.WriteString(`"`)
+								}
+								builder.WriteString(`/>`)
+							}
+							builder.WriteString(`<message id="`)
+							builder.WriteString(htmlEscape(id))
+							builder.WriteString(`" forward="true"/>`)
+						} else if innerContent, ok := innerData["content"].([]map[string]interface{}); ok {
+							// Custom content with author and nested message
+							if innerSenderName != "" || innerSenderId != "" {
+								builder.WriteString(`<author`)
+								if innerSenderName != "" {
+									builder.WriteString(` name="`)
+									builder.WriteString(htmlEscape(innerSenderName))
+									builder.WriteString(`"`)
+								}
+								if innerSenderId != "" {
+									builder.WriteString(` id="`)
+									builder.WriteString(htmlEscape(innerSenderId))
+									builder.WriteString(`"`)
+								}
+								builder.WriteString(`/>`)
+							}
+							builder.WriteString(`<message>`)
+							for _, c := range innerContent {
+								segData, _ := c["data"].(map[string]interface{})
+								seg := adapter.MessageSegment{Type: extractString(c["type"]), Data: segData}
+								builder.WriteString(a.renderMessageContent([]adapter.MessageSegment{seg}))
+							}
+							builder.WriteString(`</message>`)
+						} else if innerContent, ok := innerData["content"].(string); ok && innerContent != "" {
+							// Plain text content
+							if innerSenderName != "" || innerSenderId != "" {
+								builder.WriteString(`<author`)
+								if innerSenderName != "" {
+									builder.WriteString(` name="`)
+									builder.WriteString(htmlEscape(innerSenderName))
+									builder.WriteString(`"`)
+								}
+								if innerSenderId != "" {
+									builder.WriteString(` id="`)
+									builder.WriteString(htmlEscape(innerSenderId))
+									builder.WriteString(`"`)
+								}
+								builder.WriteString(`/>`)
+							}
+							builder.WriteString(`<message>`)
+							builder.WriteString(htmlEscape(innerContent))
+							builder.WriteString(`</message>`)
+						} else if innerContentList, ok := innerData["content"].([]interface{}); ok && len(innerContentList) > 0 {
+							// Recursively nested forward
+							if innerSenderName != "" || innerSenderId != "" {
+								builder.WriteString(`<author`)
+								if innerSenderName != "" {
+									builder.WriteString(` name="`)
+									builder.WriteString(htmlEscape(innerSenderName))
+									builder.WriteString(`"`)
+								}
+								if innerSenderId != "" {
+									builder.WriteString(` id="`)
+									builder.WriteString(htmlEscape(innerSenderId))
+									builder.WriteString(`"`)
+								}
+								builder.WriteString(`/>`)
+							}
+							builder.WriteString(`<message forward="true">`)
+							for _, innerItem := range innerContentList {
+								if innerNodeMap, ok := innerItem.(map[string]interface{}); ok {
+									innerNodeData, _ := innerNodeMap["data"].(map[string]interface{})
+									if innerNodeData == nil {
+										continue
+									}
+									innerNodeSenderName := extractString(innerNodeData["name"])
+									innerNodeSenderId := extractString(innerNodeData["uin"])
+									if innerNodeSenderName != "" || innerNodeSenderId != "" {
+										builder.WriteString(`<author`)
+										if innerNodeSenderName != "" {
+											builder.WriteString(` name="`)
+											builder.WriteString(htmlEscape(innerNodeSenderName))
+											builder.WriteString(`"`)
+										}
+										if innerNodeSenderId != "" {
+											builder.WriteString(` id="`)
+											builder.WriteString(htmlEscape(innerNodeSenderId))
+											builder.WriteString(`"`)
+										}
+										builder.WriteString(`/>`)
+									}
+									builder.WriteString(`<message>`)
+									builder.WriteString(htmlEscape(extractString(innerNodeData["content"])))
+									builder.WriteString(`</message>`)
+								}
+							}
+							builder.WriteString(`</message>`)
+						}
 					}
 				}
+				builder.WriteString(`</message>`)
 			}
 		}
 	}

--- a/adapter/satori/adapter.go
+++ b/adapter/satori/adapter.go
@@ -308,6 +308,94 @@ func (a *SatoriAdapter) SendPrivateMessage(userID int64, message interface{}) (i
 	return int32(parsed), nil
 }
 
+func (a *SatoriAdapter) SendGroupForwardMessage(groupCode int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	channelID := a.resolveGroupChannelID(groupCode)
+	if channelID == "" {
+		return 0, "", fmt.Errorf("satori group channel not found: %d", groupCode)
+	}
+
+	content := a.renderForwardContent(nodes)
+	data, err := a.SendApi("message.create", map[string]interface{}{
+		"channel_id": channelID,
+		"content":    content,
+	})
+	if err != nil {
+		logger.Warnf("Satori SendGroupForwardMessage error: %v", err)
+		return 0, "", err
+	}
+	msgID := extractStringField(data, "id")
+	if msgID == "" {
+		return 0, "", nil
+	}
+	parsed := a.rememberID(msgID)
+	a.mu.Lock()
+	a.messageChannelMap[int32(parsed)] = channelID
+	a.mu.Unlock()
+	return int32(parsed), "", nil
+}
+
+func (a *SatoriAdapter) SendPrivateForwardMessage(userID int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	channelID, err := a.resolveDirectChannelID(userID)
+	if err != nil {
+		logger.Warnf("Satori SendPrivateForwardMessage resolve channel error: %v", err)
+		return 0, "", err
+	}
+
+	content := a.renderForwardContent(nodes)
+	data, err := a.SendApi("message.create", map[string]interface{}{
+		"channel_id": channelID,
+		"content":    content,
+	})
+	if err != nil {
+		logger.Warnf("Satori SendPrivateForwardMessage error: %v", err)
+		return 0, "", err
+	}
+	msgID := extractStringField(data, "id")
+	if msgID == "" {
+		return 0, "", nil
+	}
+	parsed := a.rememberID(msgID)
+	a.mu.Lock()
+	a.messageChannelMap[int32(parsed)] = channelID
+	a.mu.Unlock()
+	return int32(parsed), "", nil
+}
+
+// renderForwardContent renders forward message nodes to satori format
+func (a *SatoriAdapter) renderForwardContent(nodes []map[string]interface{}) string {
+	if len(nodes) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	builder.WriteString(`<message forward="true">`)
+	for _, node := range nodes {
+		nodeType, _ := node["type"].(string)
+		data, _ := node["data"].(map[string]interface{})
+		if data == nil {
+			continue
+		}
+		if nodeType == "node" {
+			// Render each node as a message
+			if id, ok := data["id"].(string); ok {
+				// Reference to existing message
+				builder.WriteString(`<message id="`)
+				builder.WriteString(htmlEscape(id))
+				builder.WriteString(`" forward="true"/>`)
+			} else if content, ok := data["content"].([]interface{}); ok {
+				// Custom content - render as nested messages
+				for _, c := range content {
+					if cMap, ok := c.(map[string]interface{}); ok {
+						seg := adapter.MessageSegment{Type: extractString(cMap["type"]), Data: cMap}
+						builder.WriteString(a.renderMessageContent([]adapter.MessageSegment{seg}))
+					}
+				}
+			}
+		}
+	}
+	builder.WriteString(`</message>`)
+	return builder.String()
+}
+
 func (a *SatoriAdapter) GetSelfID() int64 {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/bot/bot/bot.go
+++ b/bot/bot/bot.go
@@ -169,6 +169,20 @@ func (bot *Bot) SendPrivateMessage(target int64, m interface{}, newstr string) *
 	return &message.PrivateMessage{Id: -1}
 }
 
+func (bot *Bot) SendGroupForwardMessage(groupCode int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	if bot.Messenger != nil {
+		return bot.Messenger.SendGroupForwardMessage(groupCode, nodes, options)
+	}
+	return -1, "", fmt.Errorf("messenger not initialized")
+}
+
+func (bot *Bot) SendPrivateForwardMessage(userID int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	if bot.Messenger != nil {
+		return bot.Messenger.SendPrivateForwardMessage(userID, nodes, options)
+	}
+	return -1, "", fmt.Errorf("messenger not initialized")
+}
+
 func (bot *Bot) GetGroupInfo(groupCode int64) (*adapter.GroupInfo, error) {
 	if bot.Messenger != nil {
 		return bot.Messenger.GetGroupInfo(groupCode)

--- a/bot/go.mod
+++ b/bot/go.mod
@@ -7,6 +7,7 @@ replace (
 	github.com/cnxysoft/DDBOT-WSa => ../
 	github.com/cnxysoft/DDBOT-WSa/adapter => ../adapter
 	github.com/cnxysoft/DDBOT-WSa/utils => ../utils
+	github.com/cnxysoft/DDBOT-WSa/utils/qqlog => ../utils/qqlog
 )
 
 require (

--- a/lsp/buntdb/shortcut.go
+++ b/lsp/buntdb/shortcut.go
@@ -15,6 +15,10 @@ import (
 	"time"
 )
 
+// extDbSortedSetIndexPrefix sorted set 索引前缀
+// 每个 setName 独立索引，索引名为 ss:{setName}，key 模式为 ss:{setName}:*
+const extDbSortedSetIndexPrefix = "ss"
+
 // ShortCut 包含了许多数据库的读写helper，只需嵌入即可使用，如果不想嵌入，也可以通过包名调用
 // 支持绑定到特定的数据库实例，实现数据库解耦
 type ShortCut struct{
@@ -363,6 +367,20 @@ func (s *ShortCut) CreatePatternIndex(patternFunc KeyPatternFunc, suffix []inter
 	})
 }
 
+// CreateSortedSetIndex 创建指定 setName 的 sorted set 索引
+// 索引名为 ss:{setName}，使用 IndexFloat 支持数值范围查询
+// key 格式为 ss:{setName}:{member}，value 为 score 的字符串表示
+func (s *ShortCut) CreateSortedSetIndex(setName string) error {
+	indexName := extDbSortedSetIndexPrefix + ":" + setName
+	return s.RWCoverTx(func(tx *buntdb.Tx) error {
+		err := tx.CreateIndex(indexName, indexName+":*", buntdb.IndexFloat)
+		if err == buntdb.ErrIndexExists {
+			err = nil
+		}
+		return err
+	})
+}
+
 // RemoveByPrefixAndIndex 遍历每个index，如果一个key满足任意prefix，则删掉
 func (s *ShortCut) RemoveByPrefixAndIndex(prefixKey []string, indexKey []string) ([]string, error) {
 	var deletedKey []string
@@ -513,4 +531,130 @@ func RemoveByPrefixAndIndex(prefixKey []string, indexKey []string) ([]string, er
 
 func CreatePatternIndex(patternFunc KeyPatternFunc, suffix []interface{}, less ...func(a, b string) bool) error {
 	return shortCut.CreatePatternIndex(patternFunc, suffix, less...)
+}
+
+// ZAdd 添加成员到有序集合
+// 索引名为 ss:{setName}，key 格式为 ss:{setName}:{member}，value 为 score 的字符串表示
+// 索引会在写入时自动创建（惰性创建）
+func (s *ShortCut) ZAdd(setName string, member string, score float64) error {
+	indexName := extDbSortedSetIndexPrefix + ":" + setName
+	indexKey := indexName + ":" + member
+	// 惰性创建索引
+	s.CreateSortedSetIndex(setName)
+	return s.RWCoverTx(func(tx *buntdb.Tx) error {
+		_, _, err := tx.Set(indexKey, strconv.FormatFloat(score, 'f', 6, 64), nil)
+		return err
+	})
+}
+
+// ZRangeByScore 根据分数范围获取成员
+// 使用 IndexFloat 直接按 score 数值范围查询，无需在 Go 层过滤
+// 注意：buntdb 索引在某些情况下可能丢失，会自动重建
+func (s *ShortCut) ZRangeByScore(setName string, min, max float64, handler func(member string, score float64) bool) error {
+	indexName := extDbSortedSetIndexPrefix + ":" + setName
+	// 确保索引存在
+	s.ensureSortedSetIndex(setName)
+	return s.RCoverTx(func(tx *buntdb.Tx) error {
+		return tx.AscendRange(indexName,
+			strconv.FormatFloat(min, 'f', 6, 64),
+			strconv.FormatFloat(max, 'f', 6, 64),
+			func(key, value string) bool {
+				// key 格式: ss:{setName}:{member}
+				member := key[len(indexName)+1:]
+				score, _ := strconv.ParseFloat(value, 64)
+				return handler(member, score)
+			})
+	})
+}
+
+// ensureSortedSetIndex 确保索引存在，如果不存在则创建
+// 如果索引丢失会重建
+func (s *ShortCut) ensureSortedSetIndex(setName string) error {
+	indexName := extDbSortedSetIndexPrefix + ":" + setName
+	// 先尝试创建索引（如果已存在会忽略错误）
+	s.CreateSortedSetIndex(setName)
+	// 验证索引是否工作：如果没有数据就不需要验证
+	var hasData bool
+	s.RCoverTx(func(tx *buntdb.Tx) error {
+		tx.Ascend(indexName, func(key, value string) bool {
+			hasData = true
+			return false // 找到一个就够了，停止遍历
+		})
+		return nil
+	})
+	// 如果有数据但索引不工作，需要重建
+	if hasData {
+		// 检查索引是否能被 AscendRange 使用
+		var indexWorks bool
+		s.RCoverTx(func(tx *buntdb.Tx) error {
+			tx.AscendRange(indexName, "-inf", "+inf", func(key, value string) bool {
+				indexWorks = true
+				return false
+			})
+			return nil
+		})
+		if !indexWorks {
+			// 索引丢失，重新创建
+			s.rebuildSortedSetIndex(setName)
+		}
+	}
+	return nil
+}
+
+// rebuildSortedSetIndex 重建 sorted set 的索引
+// 通过遍历所有以 ss:{setName}: 开头的 key 来重建索引
+func (s *ShortCut) rebuildSortedSetIndex(setName string) error {
+	indexName := extDbSortedSetIndexPrefix + ":" + setName
+	// 收集所有需要重建的 key
+	var keys []string
+	s.RCoverTx(func(tx *buntdb.Tx) error {
+		tx.Ascend("", func(key, value string) bool {
+			if strings.HasPrefix(key, indexName+":") {
+				keys = append(keys, key)
+			}
+			return true
+		})
+		return nil
+	})
+	if len(keys) == 0 {
+		return nil
+	}
+	// 重建索引：通过重新 Set 这些 key
+	return s.RWCoverTx(func(tx *buntdb.Tx) error {
+		for _, key := range keys {
+			val, err := tx.Get(key)
+			if err != nil {
+				continue
+			}
+			tx.Set(key, val, nil)
+		}
+		return nil
+	})
+}
+
+// ZRem 从有序集合移除成员
+func (s *ShortCut) ZRem(setName string, members ...string) error {
+	indexName := extDbSortedSetIndexPrefix + ":" + setName
+	return s.RWCoverTx(func(tx *buntdb.Tx) error {
+		for _, member := range members {
+			indexKey := indexName + ":" + member
+			tx.Delete(indexKey)
+		}
+		return nil
+	})
+}
+
+// ZAdd 添加成员到有序集合（全局函数）
+func ZAdd(setName string, member string, score float64) error {
+	return shortCut.ZAdd(setName, member, score)
+}
+
+// ZRangeByScore 根据分数范围获取成员（全局函数）
+func ZRangeByScore(setName string, min, max float64, handler func(member string, score float64) bool) error {
+	return shortCut.ZRangeByScore(setName, min, max, handler)
+}
+
+// ZRem 从有序集合移除成员（全局函数）
+func ZRem(setName string, members ...string) error {
+	return shortCut.ZRem(setName, members...)
 }

--- a/lsp/groupCommand.go
+++ b/lsp/groupCommand.go
@@ -67,27 +67,26 @@ func (lgc *LspGroupCommand) Execute() {
 		}
 	}()
 
-	if len(lgc.CommandName()) == 0 {
-		return
-	}
-
-	log := lgc.DefaultLogger().WithField("cmd", lgc.GetCmdArgs())
-
 	if lgc.l.PermissionStateManager.CheckBlockList(lgc.uin()) ||
 		lgc.l.PermissionStateManager.CheckBlockList(lgc.groupCode()) {
-		log.Debug("blocked")
 		return
 	}
 
 	if !lgc.DebugCheck() {
-		log.Debugf("debug mode, skip execute.")
+		return
+	}
+
+	if len(lgc.CommandName()) == 0 {
+		// 非命令消息，执行通用消息模板
+		lgc.groupMessageTemplate(false, false)
 		return
 	}
 
 	if !lgc.AtCheck() {
-		log.Debugf("at check fail, skip execute")
 		return
 	}
+
+	log := lgc.DefaultLogger().WithField("cmd", lgc.GetCmdArgs())
 
 	log.Debug("execute command")
 
@@ -194,6 +193,8 @@ func (lgc *LspGroupCommand) Execute() {
 			log.Debug("no command matched")
 		}
 	}
+	// 命令执行完成后，执行通用消息模板（所有消息都触发）
+	lgc.groupMessageTemplate(true, true)
 	return
 }
 
@@ -1109,6 +1110,28 @@ func (lgc *LspGroupCommand) templateMsg(name string, data map[string]interface{}
 		return nil
 	}
 	return m
+}
+
+// groupMessageTemplate 执行通用群消息处理模板
+// isCommand: 是否有命令前缀（消息是否为命令）
+// isMatched: 命令是否匹配到了处理函数（仅当 isCommand 为 true 时有意义）
+func (lgc *LspGroupCommand) groupMessageTemplate(isCommand, isMatched bool) {
+	const templateName = "trigger.group.message.tmpl"
+	if template.LoadTemplate(templateName) == nil {
+		return
+	}
+	data := lgc.commonTemplateData()
+	data["isCommand"] = isCommand
+	data["isMatched"] = isMatched
+	data["commandName"] = lgc.CommandName()
+	m, err := template.LoadAndExec(templateName, data)
+	if err != nil {
+		logger.Errorf("groupMessageTemplate error %v", err)
+		return
+	}
+	if m != nil && len(m.Elements()) > 0 {
+		lgc.sendChain(m)
+	}
 }
 
 func (lgc *LspGroupCommand) NewMessageContext(log *logrus.Entry) *MessageContext {

--- a/lsp/mmsg/file.go
+++ b/lsp/mmsg/file.go
@@ -2,11 +2,13 @@ package mmsg
 
 import (
 	"encoding/base64"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/Mrs4s/MiraiGo/message"
 	"github.com/cnxysoft/DDBOT-WSa/requests"
 	"github.com/cnxysoft/DDBOT-WSa/utils"
-	"strconv"
-	"strings"
 )
 
 type FileElement struct {
@@ -24,6 +26,17 @@ func NewFile(url string, Buf ...any) *FileElement {
 	}
 	if len(Buf) > 0 {
 		f.Buf = Buf[0].([]byte)
+	}
+	return f
+}
+
+func NewFileByLocal(path string) *FileElement {
+	f := &FileElement{}
+	b, err := os.ReadFile(path)
+	if err == nil {
+		f.Buf = b
+	} else {
+		logger.WithField("filepath", path).Errorf("ReadFile error %v", err)
 	}
 	return f
 }
@@ -62,6 +75,24 @@ func (f *FileElement) Length(s string) *FileElement {
 	i, _ := strconv.ParseInt(s, 10, 64)
 	f.length = i
 	return f
+}
+
+// GetFile 返回可用于发送/转发的文件字符串
+// 优先级：Url > base64(Buf) > alternative
+func (f *FileElement) GetFile() string {
+	if f == nil {
+		return ""
+	}
+	if f.Url != "" {
+		if strings.HasPrefix(f.Url, "http://") || strings.HasPrefix(f.Url, "https://") {
+			return f.Url
+		}
+		return "file://" + strings.ReplaceAll(f.Url, `\`, `\\`)
+	}
+	if f.Buf != nil && len(f.Buf) > 0 {
+		return "base64://" + base64.StdEncoding.EncodeToString(f.Buf)
+	}
+	return f.alternative
 }
 
 func (f *FileElement) Type() message.ElementType {

--- a/lsp/mmsg/forward.go
+++ b/lsp/mmsg/forward.go
@@ -1,0 +1,43 @@
+package mmsg
+
+import (
+	"github.com/Mrs4s/MiraiGo/message"
+)
+
+// ForwardOptions 合并转发消息的顶层参数
+// 对应 onebot-v11 send_group_forward_msg API 的顶层字段
+type ForwardOptions struct {
+	Prompt  string   // 转发消息外显标题 (LLOneBot/NapCatQQ 支持)
+	Source  string   // 转发来源 (LLOneBot/NapCatQQ 支持)
+	Summary string   // 转发摘要 (LLOneBot/NapCatQQ 支持)
+	News    []string // 转发预览文本列表 (LLOneBot/NapCatQQ 支持)
+}
+
+// ForwardElement 用于在模板中构建合并转发消息
+// 当 Append 到 MSG 时，会将节点列表复制到 MSG.ForwardNodes
+type ForwardElement struct {
+	Nodes   []map[string]interface{} // onebot-v11 格式的节点列表
+	Options *ForwardOptions           // 顶层参数 (prompt, source, summary, news)
+}
+
+// Type 实现 message.IMessageElement 接口
+func (f *ForwardElement) Type() message.ElementType {
+	return message.Forward
+}
+
+// PackToElement 实现 CustomElement 接口，返回 message.ForwardElement
+// 由于 onebot-v11 的转发消息不走 MiraiGo 的转发协议，这里返回 nil
+// 实际转发消息通过 SendGroupForwardMessage / SendPrivateForwardMessage API 发送
+func (f *ForwardElement) PackToElement(target Target) message.IMessageElement {
+	return nil // 不通过 MiraiGo 原生协议发送
+}
+
+// NewForwardElement 创建一个转发消息元素
+func NewForwardElement(nodes []map[string]interface{}) *ForwardElement {
+	return &ForwardElement{Nodes: nodes}
+}
+
+// NewForwardElementWithOptions 创建一个带顶层参数的转发消息元素
+func NewForwardElementWithOptions(nodes []map[string]interface{}, options *ForwardOptions) *ForwardElement {
+	return &ForwardElement{Nodes: nodes, Options: options}
+}

--- a/lsp/mmsg/image.go
+++ b/lsp/mmsg/image.go
@@ -95,6 +95,24 @@ func (i *ImageBytesElement) Alternative(s string) *ImageBytesElement {
 	return i
 }
 
+// GetFile 返回可用于发送/转发的文件字符串
+// 优先级：Url > base64(Buf) > alternative
+func (i *ImageBytesElement) GetFile() string {
+	if i == nil {
+		return ""
+	}
+	if i.Url != "" {
+		if strings.HasPrefix(i.Url, "http://") || strings.HasPrefix(i.Url, "https://") {
+			return i.Url
+		}
+		return "file://" + strings.ReplaceAll(i.Url, `\`, `\\`)
+	}
+	if i.Buf != nil && len(i.Buf) > 0 {
+		return "base64://" + base64.StdEncoding.EncodeToString(i.Buf)
+	}
+	return i.alternative
+}
+
 func (i *ImageBytesElement) Type() message.ElementType {
 	return ImageBytes
 }

--- a/lsp/mmsg/record.go
+++ b/lsp/mmsg/record.go
@@ -2,10 +2,12 @@ package mmsg
 
 import (
 	"encoding/base64"
+	"os"
+	"strings"
+
 	"github.com/Mrs4s/MiraiGo/message"
 	"github.com/cnxysoft/DDBOT-WSa/requests"
 	"github.com/cnxysoft/DDBOT-WSa/utils"
-	"strings"
 )
 
 type RecordElement struct {
@@ -21,6 +23,17 @@ func NewRecord(url string, Buf ...any) *RecordElement {
 	}
 	if len(Buf) > 0 {
 		r.Buf = Buf[0].([]byte)
+	}
+	return r
+}
+
+func NewRecordByLocal(path string) *RecordElement {
+	r := &RecordElement{}
+	b, err := os.ReadFile(path)
+	if err == nil {
+		r.Buf = b
+	} else {
+		logger.WithField("filepath", path).Errorf("ReadFile error %v", err)
 	}
 	return r
 }
@@ -42,6 +55,24 @@ func NewRecordByUrl(url string, opts ...requests.Option) *RecordElement {
 func (r *RecordElement) Alternative(s string) *RecordElement {
 	r.alternative = s
 	return r
+}
+
+// GetFile 返回可用于发送/转发的文件字符串
+// 优先级：Url > base64(Buf) > alternative
+func (r *RecordElement) GetFile() string {
+	if r == nil {
+		return ""
+	}
+	if r.Url != "" {
+		if strings.HasPrefix(r.Url, "http://") || strings.HasPrefix(r.Url, "https://") {
+			return r.Url
+		}
+		return "file://" + strings.ReplaceAll(r.Url, `\`, `\\`)
+	}
+	if r.Buf != nil && len(r.Buf) > 0 {
+		return "base64://" + base64.StdEncoding.EncodeToString(r.Buf)
+	}
+	return r.alternative
 }
 
 func (r *RecordElement) Type() message.ElementType {

--- a/lsp/mmsg/video.go
+++ b/lsp/mmsg/video.go
@@ -56,6 +56,24 @@ func (v *VideoElement) Alternative(s string) *VideoElement {
 	return v
 }
 
+// GetFile 返回可用于发送/转发的文件字符串
+// 优先级：Url > base64(Buf) > alternative
+func (v *VideoElement) GetFile() string {
+	if v == nil {
+		return ""
+	}
+	if v.Url != "" {
+		if strings.HasPrefix(v.Url, "http://") || strings.HasPrefix(v.Url, "https://") {
+			return v.Url
+		}
+		return "file://" + strings.ReplaceAll(v.Url, `\`, `\\`)
+	}
+	if v.Buf != nil && len(v.Buf) > 0 {
+		return "base64://" + base64.StdEncoding.EncodeToString(v.Buf)
+	}
+	return v.alternative
+}
+
 func (v *VideoElement) Type() message.ElementType {
 	return Video
 }

--- a/lsp/module.go
+++ b/lsp/module.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Sora233/MiraiGo-Template/bot"
 	"github.com/Sora233/MiraiGo-Template/config"
 	"github.com/Sora233/sliceutil"
+	"github.com/cnxysoft/DDBOT-WSa/adapter"
 	"github.com/cnxysoft/DDBOT-WSa/image_pool"
 	"github.com/cnxysoft/DDBOT-WSa/image_pool/local_pool"
 	"github.com/cnxysoft/DDBOT-WSa/image_pool/lolicon_pool"
@@ -301,6 +302,7 @@ func (l *Lsp) Serve(bot *bot.Bot) {
 			"group_code":   event.GroupCode,
 			"author_uin":   event.AuthorUin,
 			"operator_uin": event.OperatorUin,
+			"message_id":   event.MessageId,
 		}
 		if gi := localutils.GetBot().FindGroup(event.GroupCode); gi != nil {
 			data["group_name"] = gi.Name
@@ -1068,6 +1070,54 @@ func (l *Lsp) send(msg *message.SendingMessage, target mmsg.Target) interface{} 
 
 // SendMsg 总是返回至少一个
 func (l *Lsp) SendMsg(m *mmsg.MSG, target mmsg.Target) (res []interface{}) {
+	if m == nil {
+		switch target.TargetType() {
+		case mmsg.TargetPrivate:
+			res = append(res, &message.PrivateMessage{Id: -1})
+		case mmsg.TargetGroup:
+			res = append(res, &message.GroupMessage{Id: -1})
+		}
+		return
+	}
+
+	// 检查 elements 中是否有 ForwardElement
+	var forwardNodes []map[string]interface{}
+	var forwardOptions *adapter.ForwardOptions
+	for _, elem := range m.Elements() {
+		if fe, ok := elem.(*mmsg.ForwardElement); ok {
+			forwardNodes = append(forwardNodes, fe.Nodes...)
+			if fe.Options != nil {
+				// 转换 mmsg.ForwardOptions 为 adapter.ForwardOptions
+				forwardOptions = &adapter.ForwardOptions{
+					Prompt:  fe.Options.Prompt,
+					Source:  fe.Options.Source,
+					Summary: fe.Options.Summary,
+					News:    fe.Options.News,
+				}
+			}
+		}
+	}
+
+	if len(forwardNodes) > 0 {
+		switch target.TargetType() {
+		case mmsg.TargetPrivate:
+			msgID, _, err := l.sendPrivateForwardMessage(target.TargetCode(), forwardNodes, forwardOptions)
+			if err != nil {
+				res = append(res, &message.PrivateMessage{Id: -1})
+			} else {
+				res = append(res, &message.PrivateMessage{Id: msgID})
+			}
+		case mmsg.TargetGroup:
+			msgID, _, err := l.sendGroupForwardMessage(target.TargetCode(), forwardNodes, forwardOptions)
+			if err != nil {
+				res = append(res, &message.GroupMessage{Id: -1})
+			} else {
+				res = append(res, &message.GroupMessage{Id: msgID})
+			}
+		}
+		return
+	}
+
 	msgs := m.ToMessage(target)
 	if len(msgs) == 0 {
 		switch target.TargetType() {
@@ -1195,6 +1245,22 @@ func (l *Lsp) sendGroupMessage(groupCode int64, msg *message.SendingMessage, rec
 	return res
 }
 
+// sendGroupForwardMessage 发送群合并转发消息
+func (l *Lsp) sendGroupForwardMessage(groupCode int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	if bot.Instance == nil {
+		return -1, "", fmt.Errorf("bot not initialized")
+	}
+	return bot.Instance.SendGroupForwardMessage(groupCode, nodes, options)
+}
+
+// sendPrivateForwardMessage 发送私聊合并转发消息
+func (l *Lsp) sendPrivateForwardMessage(userID int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	if bot.Instance == nil {
+		return -1, "", fmt.Errorf("bot not initialized")
+	}
+	return bot.Instance.SendPrivateForwardMessage(userID, nodes, options)
+}
+
 var Instance = &Lsp{
 	concernNotify:          concern.ReadNotifyChan(),
 	stop:                   make(chan interface{}),
@@ -1211,4 +1277,6 @@ func init() {
 	template.RegisterExtFunc("currentMode", func() string {
 		return string(Instance.LspStateManager.GetCurrentMode())
 	})
+
+	// 注意：sorted set 索引在 ZAdd 时惰性创建，无需在 init 中预创建
 }

--- a/lsp/template/funcs.go
+++ b/lsp/template/funcs.go
@@ -141,6 +141,11 @@ func builtins() FuncMap {
 		"getOptions":  getOptions,
 		"newDuration": newDuration,
 
+		// sorted set
+		"ZAdd":         ZAdd,
+		"ZRangeByScore": ZRangeByScore,
+		"ZRem":         ZRem,
+
 		// cast
 		"float64": toFloat64,
 		"int":     toInt,

--- a/lsp/template/funcs_db_ext.go
+++ b/lsp/template/funcs_db_ext.go
@@ -168,6 +168,35 @@ func existData(key string, opts ...[]localdb.OptionFunc) bool {
 	return GetTemplateSC().Exist(localdb.ExtDbCustomKey(Keys...), opt...)
 }
 
+// ZAdd adds a member to a sorted set.
+// setName: sorted set 名称（如 "AtMsgList"、"ReserveList"）
+// member: 成员标识
+// score: 分数/排序值（支持 float64、string、int 等类型，内部自动转换）
+func ZAdd(setName string, member string, score interface{}) error {
+	return GetTemplateSC().ZAdd(setName, member, toFloat64(score))
+}
+
+// ZRangeByScore returns members within a score range.
+// setName: sorted set 名称
+// min/max: 分数范围（支持 float64、string、int 等类型，内部自动转换）
+// Returns a list of maps with "member" and "score" keys.
+func ZRangeByScore(setName string, min, max interface{}) []map[string]interface{} {
+	var result []map[string]interface{}
+	GetTemplateSC().ZRangeByScore(setName, toFloat64(min), toFloat64(max), func(member string, score float64) bool {
+		result = append(result, map[string]interface{}{
+			"member": member,
+			"score":  score,
+		})
+		return true
+	})
+	return result
+}
+
+// ZRem removes members from a sorted set.
+func ZRem(setName string, members ...string) error {
+	return GetTemplateSC().ZRem(setName, members...)
+}
+
 func getOptions(opt []interface{}, param ...interface{}) []localdb.OptionFunc {
 	var opts []localdb.OptionFunc
 	for _, iopt := range opt {

--- a/lsp/template/funcs_ext.go
+++ b/lsp/template/funcs_ext.go
@@ -121,6 +121,10 @@ func botUin() int64 {
 	return localutils.GetBot().GetUin()
 }
 
+func now() int64 {
+	return time.Now().Unix()
+}
+
 func isAdmin(uin int64, groupCode ...int64) bool {
 	key := localdb.Key("Permission", uin, "Admin")
 	ret := localdb.Exist(key)
@@ -779,7 +783,7 @@ func videoUri(uri string) (e *mmsg.VideoElement) {
 		}
 	END:
 		if e == nil {
-			e = mmsg.NewVideo(uri)
+			e = mmsg.NewVideoByLocal(uri)
 		}
 	}
 	return e
@@ -846,7 +850,7 @@ func recordUri(uri string) (e *mmsg.RecordElement) {
 		}
 	END:
 		if e == nil {
-			e = mmsg.NewRecord(uri)
+			e = mmsg.NewRecordByLocal(uri)
 		}
 	}
 	return e
@@ -909,7 +913,7 @@ func fileUri(uri string) (e *mmsg.FileElement) {
 		}
 	END:
 		if e == nil {
-			e = mmsg.NewFile(uri)
+			e = mmsg.NewFileByLocal(uri)
 		}
 	}
 	return e
@@ -985,15 +989,34 @@ func getFileUrl(groupCode int64, fileId string) string {
 	return botInstance.GetFileUrl(groupCode, fileId)
 }
 
-func getMsg(msgId int32) interface{} {
+// toInt32 converts various types to int32 for template functions
+func toInt32(v interface{}) int32 {
+	switch val := v.(type) {
+	case int32:
+		return val
+	case int64:
+		return int32(val)
+	case int:
+		return int32(val)
+	case float64:
+		return int32(val)
+	case string:
+		if i, err := strconv.ParseInt(val, 10, 32); err == nil {
+			return int32(i)
+		}
+	}
+	return 0
+}
+
+func getMsg(msgId interface{}) interface{} {
 	botInstance := localutils.GetBot()
 	if botInstance == nil {
 		logger.Error("bot 实例未找到")
 		return nil
 	}
-	ret, err := botInstance.GetMsg(msgId)
+	ret, err := botInstance.GetMsg(toInt32(msgId))
 	if err != nil {
-		logger.Errorf("获取消息失败: %v", err)
+		logger.Tracef("获取消息失败: %v", err)
 		return nil
 	}
 	return ret

--- a/lsp/template/funcs_ext_test.go
+++ b/lsp/template/funcs_ext_test.go
@@ -207,8 +207,7 @@ func TestVideoFuncs(t *testing.T) {
 	// 测试video函数
 	e := video(videoFile)
 	assert.NotNil(t, e)
-	assert.EqualValues(t, videoFile, e.Url)
-	//assert.EqualValues(t, []byte{4, 5, 6, 7}, e.Buf)
+	assert.EqualValues(t, []byte{4, 5, 6, 7}, e.Buf)
 
 	// 测试videoUri函数
 	e = videoUri(tempDir)
@@ -237,8 +236,7 @@ func TestRecordFuncs(t *testing.T) {
 	// 测试record函数
 	e := record(recordFile)
 	assert.NotNil(t, e)
-	assert.EqualValues(t, recordFile, e.Url)
-	//assert.EqualValues(t, []byte{8, 9, 10, 11}, e.Buf)
+	assert.EqualValues(t, []byte{8, 9, 10, 11}, e.Buf)
 
 	// 测试recordUri函数
 	e = recordUri(tempDir)

--- a/lsp/template/funcs_forward.go
+++ b/lsp/template/funcs_forward.go
@@ -1,0 +1,402 @@
+package template
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/Mrs4s/MiraiGo/message"
+	"github.com/cnxysoft/DDBOT-WSa/adapter"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/mmsg"
+	localutils "github.com/cnxysoft/DDBOT-WSa/utils"
+)
+
+// forward 构建合并转发消息
+//
+// Usage:
+//
+//	{{ forward (list
+//	  (dict "message" $msg)
+//	) }}
+//
+//	{{ forward (list
+//	  (dict "senderName" "张三" "senderId" 123456 "time" 1234567890 "message" $msg)
+//	  (dict "senderName" "李四" "senderId" 654321 "time" 1234567891 "elements" $msg.Elements "content" "文本")
+//	) (dict "prompt" "转发标题") }}
+//
+// 最简用法（不提供 sender 信息，自动使用 BOT 信息）:
+//
+//	{{ forward (list
+//	  (dict "content" "最简单的用法")
+//	) (dict "prompt" "转发标题") }}
+//
+// 嵌套转发（支持最多3层）:
+//
+//	{{- $innerForward := forward (list
+//	  (dict "senderName" "内层发送者" "senderId" 111111 "content" "这是内层消息")
+//	) -}}
+//	{{- forward (list
+//	  (dict "senderName" "外层发送者" "senderId" 222222 "content" $innerForward)
+//	) (dict "prompt" "嵌套转发测试") -}}
+//
+// Parameters:
+//   - nodes []interface{}: 转发节点列表，每个节点包含（字段优先级从高到低）：
+//   - message: 原始消息（*message.GroupMessage/*message.PrivateMessage），会提取发送人信息和元素
+//   - elements: 消息元素列表，会覆盖 message 的元素
+//   - content: 文本内容、*mmsg.ForwardElement（嵌套转发）或其他可转发内容
+//   - senderName: 发送者昵称（可选，未提供时使用 "BOT"）
+//   - senderId: 发送者QQ号（可选，未提供时使用 BOT 的 Uin）
+//   - time: Unix时间戳（可选，未提供时使用当前时间）
+//   - options map[string]interface{}: 顶层参数（可选）:
+//   - prompt string: 转发消息外显标题 (LLOneBot/NapCatQQ 支持)
+//   - source string: 转发来源 (LLOneBot/NapCatQQ 支持)
+//   - summary string: 转发摘要 (LLOneBot/NapCatQQ 支持)
+//
+// Returns: *mmsg.ForwardElement - 可以直接 Append 到 MSG 中
+//
+// Sender 信息默认值（当未提供时）：
+//   - senderName: "BOT"
+//   - senderId: BOT 的 Uin
+//   - time: 当前 Unix 时间戳
+//
+// 框架兼容性说明:
+//   - NapCatQQ: 必须字段 name, uin, content
+//   - LLOneBot: 必须字段 content；可选 name, uin
+func forward(nodes []interface{}, options ...map[string]interface{}) *mmsg.ForwardElement {
+	ob11Nodes := make([]map[string]interface{}, 0, len(nodes))
+
+	for _, node := range nodes {
+		nodeMap, ok := node.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// 提取 sender 信息（优先级：指定 > message > 默认）
+		senderName, _ := nodeMap["senderName"].(string)
+		senderId, _ := nodeMap["senderId"].(int64)
+		timeVal, _ := nodeMap["time"].(int32)
+
+		var content interface{}
+		var msgSender *senderInfo
+
+		// 如果有 message，提取发送人信息和元素
+		if msg := nodeMap["message"]; msg != nil {
+			msgSender = extractMessageSender(msg)
+			content = extractMessageContent(msg)
+			// 如果提取结果为空或只有空数组，回退到 content
+			if contentList, ok := content.([]map[string]interface{}); !ok || len(contentList) == 0 {
+				if fallback, ok := nodeMap["content"].(string); ok && fallback != "" {
+					content = fallback
+				} else {
+					content = "" // 确保 content 有值
+				}
+			}
+		} else if elements, ok := nodeMap["elements"].([]interface{}); ok && len(elements) > 0 {
+			// 有 elements，使用 elements
+			content = extractElementsContent(elements)
+			if contentList, ok := content.([]map[string]interface{}); !ok || len(contentList) == 0 {
+				if fallback, ok := nodeMap["content"].(string); ok && fallback != "" {
+					content = fallback
+				} else {
+					content = ""
+				}
+			}
+		} else {
+			// 只有 content
+			content = nodeMap["content"]
+		}
+
+		// 如果有 message，message 的发送人信息覆盖指定值
+		if msgSender != nil {
+			if senderName == "" {
+				// 优先用群昵称，其次昵称
+				if msgSender.CardName != "" {
+					senderName = msgSender.CardName
+				} else if msgSender.Nickname != "" {
+					senderName = msgSender.Nickname
+				}
+			}
+			if senderId == 0 {
+				senderId = msgSender.Uin
+			}
+		}
+
+		// 如果 sender 信息仍然为空，使用 BOT 信息作为默认值
+		if senderName == "" {
+			senderName = "BOT"
+		}
+		if senderId == 0 {
+			senderId = localutils.GetBot().GetUin()
+		}
+		if timeVal == 0 {
+			timeVal = int32(time.Now().Unix())
+		}
+
+		// 如果 content 是 *mmsg.ForwardElement，递归提取内层节点作为嵌套内容
+		// QQ 支持最多 3 层嵌套
+		if fe, ok := content.(*mmsg.ForwardElement); ok && fe != nil {
+			// 将内层节点的 Nodes 转换为嵌套的 node 节点
+			var nestedContent []interface{}
+			for _, innerNode := range fe.Nodes {
+				nestedContent = append(nestedContent, innerNode)
+			}
+			content = nestedContent
+		}
+
+		// 构建 onebot-v11 node 格式
+		nodeData := map[string]interface{}{
+			"name":    senderName,
+			"uin":     senderId,
+			"time":    timeVal,
+			"content": content,
+		}
+		ob11Nodes = append(ob11Nodes, map[string]interface{}{
+			"type": "node",
+			"data": nodeData,
+		})
+	}
+
+	return buildForwardElement(ob11Nodes, options...)
+}
+
+// senderInfo 用于统一发送人信息
+type senderInfo struct {
+	Uin      int64
+	Nickname string
+	CardName string
+}
+
+// extractMessageContent 从原始消息中提取转发内容
+func extractMessageContent(msg interface{}) interface{} {
+	switch m := msg.(type) {
+	case *message.GroupMessage:
+		return extractIMessageElements(m.Elements)
+	case *message.PrivateMessage:
+		return extractIMessageElements(m.Elements)
+	case *adapter.GetMsgResult:
+		return extractIMessageElements(m.Elements)
+	}
+	return nil
+}
+
+// extractMessageSender 从原始消息中提取发送人信息
+func extractMessageSender(msg interface{}) *senderInfo {
+	switch m := msg.(type) {
+	case *message.GroupMessage:
+		return &senderInfo{Uin: m.Sender.Uin, Nickname: m.Sender.Nickname, CardName: m.Sender.CardName}
+	case *message.PrivateMessage:
+		return &senderInfo{Uin: m.Sender.Uin, Nickname: m.Sender.Nickname, CardName: m.Sender.CardName}
+	case *adapter.GetMsgResult:
+		if m.Sender != nil {
+			return &senderInfo{Uin: m.Sender.UserID, Nickname: m.Sender.Nickname, CardName: m.Sender.Card}
+		}
+	}
+	return nil
+}
+
+// extractIMessageElements 将 []message.IMessageElement 转换为转发格式
+// 返回 []map[string]interface{}，每个元素包含 type 和 data 字段（onebot 标准格式）
+func extractIMessageElements(elems []message.IMessageElement) []map[string]interface{} {
+	var contentList []map[string]interface{}
+	for _, elem := range elems {
+		if elem == nil {
+			continue
+		}
+		seg := convertToMessageSegment(elem)
+		if seg.Type != "" && seg.Data != nil {
+			contentList = append(contentList, map[string]interface{}{
+				"type": seg.Type,
+				"data": seg.Data,
+			})
+		}
+	}
+	return contentList
+}
+
+// extractElementsContent 将 []interface{} 转换为转发格式
+// 返回 []map[string]interface{}，每个元素包含 type 和 data 字段（onebot 标准格式）
+// 支持 string 类型自动转换为 text 消息段
+func extractElementsContent(elems []interface{}) interface{} {
+	var contentList []map[string]interface{}
+	for _, elem := range elems {
+		// 处理字符串类型，自动转换为 text 消息段
+		if s, ok := elem.(string); ok && s != "" {
+			contentList = append(contentList, map[string]interface{}{
+				"type": "text",
+				"data": map[string]interface{}{"text": s},
+			})
+			continue
+		}
+		// 处理 message.IMessageElement 类型
+		if imsg, ok := elem.(message.IMessageElement); ok {
+			seg := convertToMessageSegment(imsg)
+			if seg.Type != "" {
+				contentList = append(contentList, map[string]interface{}{
+					"type": seg.Type,
+					"data": seg.Data,
+				})
+			}
+		}
+	}
+	return contentList
+}
+
+// buildForwardElement 根据节点和选项创建 ForwardElement
+func buildForwardElement(nodes []map[string]interface{}, options ...map[string]interface{}) *mmsg.ForwardElement {
+	if len(options) == 0 || options[0] == nil {
+		return mmsg.NewForwardElement(nodes)
+	}
+
+	opts := &mmsg.ForwardOptions{}
+	if v, ok := options[0]["prompt"].(string); ok {
+		opts.Prompt = v
+	}
+	if v, ok := options[0]["source"].(string); ok {
+		opts.Source = v
+	}
+	if v, ok := options[0]["summary"].(string); ok {
+		opts.Summary = v
+	}
+	if v, ok := options[0]["news"].([]interface{}); ok {
+		for _, n := range v {
+			if s, ok := n.(string); ok {
+				opts.News = append(opts.News, s)
+			}
+		}
+	}
+
+	return mmsg.NewForwardElementWithOptions(nodes, opts)
+}
+
+// forwardMsgSegment 是消息段的内部表示
+type forwardMsgSegment struct {
+	Type string
+	Data map[string]interface{}
+}
+
+// convertToMessageSegment 将 message.IMessageElement 转换为 MessageSegment 格式
+func convertToMessageSegment(elem message.IMessageElement) forwardMsgSegment {
+	switch e := elem.(type) {
+	// message 包类型
+	case *message.TextElement:
+		return forwardMsgSegment{
+			Type: "text",
+			Data: map[string]interface{}{"text": e.Content},
+		}
+	case *message.AtElement:
+		qq := "all"
+		if e.Target != 0 {
+			qq = strconv.FormatInt(e.Target, 10)
+		}
+		return forwardMsgSegment{
+			Type: "at",
+			Data: map[string]interface{}{"qq": qq},
+		}
+	case *message.FaceElement:
+		return forwardMsgSegment{
+			Type: "face",
+			Data: map[string]interface{}{"id": e.Index},
+		}
+	case *message.GroupImageElement:
+		return forwardMsgSegment{
+			Type: "image",
+			Data: map[string]interface{}{
+				"name": e.Name,
+				"file": e.Url,
+			},
+		}
+	case *message.FriendImageElement:
+		return forwardMsgSegment{
+			Type: "image",
+			Data: map[string]interface{}{
+				"file": e.Url,
+			},
+		}
+	case *message.VoiceElement:
+		return forwardMsgSegment{
+			Type: "record",
+			Data: map[string]interface{}{
+				"name": e.Name,
+				"file": e.Url,
+			},
+		}
+	case *message.ReplyElement:
+		return forwardMsgSegment{
+			Type: "reply",
+			Data: map[string]interface{}{"id": e.ReplySeq},
+		}
+	case *message.LightAppElement:
+		return forwardMsgSegment{
+			Type: "json",
+			Data: map[string]interface{}{"data": e.Content},
+		}
+	// mmsg 包类型
+	case *mmsg.ImageBytesElement:
+		file := e.GetFile()
+		if file != "" {
+			return forwardMsgSegment{
+				Type: "image",
+				Data: map[string]interface{}{
+					"file": file,
+				},
+			}
+		}
+		return forwardMsgSegment{}
+	case *mmsg.AtElement:
+		qq := "all"
+		if e.Target != 0 {
+			qq = strconv.FormatInt(e.Target, 10)
+		}
+		return forwardMsgSegment{
+			Type: "at",
+			Data: map[string]interface{}{"qq": qq},
+		}
+	case *mmsg.PokeElement:
+		return forwardMsgSegment{
+			Type: "poke",
+			Data: map[string]interface{}{"uin": e.Uin},
+		}
+	case *mmsg.CutElement:
+		return forwardMsgSegment{
+			Type: "cut",
+			Data: nil,
+		}
+	case *mmsg.RecordElement:
+		file := e.GetFile()
+		if file != "" {
+			return forwardMsgSegment{
+				Type: "record",
+				Data: map[string]interface{}{
+					"file": file,
+				},
+			}
+		}
+		return forwardMsgSegment{}
+	case *mmsg.VideoElement:
+		file := e.GetFile()
+		if file != "" {
+			return forwardMsgSegment{
+				Type: "video",
+				Data: map[string]interface{}{
+					"file": file,
+				},
+			}
+		}
+		return forwardMsgSegment{}
+	case *mmsg.FileElement:
+		file := e.GetFile()
+		if file != "" {
+			return forwardMsgSegment{
+				Type: "file",
+				Data: map[string]interface{}{
+					"file": file,
+				},
+			}
+		}
+		return forwardMsgSegment{}
+	}
+	return forwardMsgSegment{}
+}
+
+func init() {
+	RegisterExtFunc("forward", forward)
+}

--- a/utils/hackedBot.go
+++ b/utils/hackedBot.go
@@ -132,6 +132,20 @@ func (h *HackedBot) SendApi(api string, params map[string]interface{}) (interfac
 	return h.Bot.SendApi(api, params)
 }
 
+func (h *HackedBot) SendGroupForwardMessage(groupCode int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	if !h.valid() {
+		return -1, "", fmt.Errorf("bot not valid")
+	}
+	return h.Bot.SendGroupForwardMessage(groupCode, nodes, options)
+}
+
+func (h *HackedBot) SendPrivateForwardMessage(userID int64, nodes []map[string]interface{}, options *adapter.ForwardOptions) (int32, string, error) {
+	if !h.valid() {
+		return -1, "", fmt.Errorf("bot not valid")
+	}
+	return h.Bot.SendPrivateForwardMessage(userID, nodes, options)
+}
+
 func (h *HackedBot) TESTSetUin(uin int64) {
 	h.testUin = uin
 }


### PR DESCRIPTION
## Summary
- **forward**: 支持合并转发消息，包含嵌套转发(最多3层)
- **buntdb sorted set**: ZAdd/ZRangeByScore/ZRem 使用 IndexFloat 支持数值范围查询，添加索引恢复机制
- **URI函数修复**: pic/video/record/file 的 ByLocal 统一处理本地文件
- **adapter**: 新增 SendGroupForwardMessage/SendPrivateForwardMessage API
- **mmsg**: 新增 GetFile() 方法统一获取文件路径/base64
- **模板函数**: 新增 now() 返回当前时间戳

## Test plan
- [x] 测试 forward 最简用法（不提供 sender 信息）
- [x] 测试 forward 带 elements（文本、at、图片混合）
- [x] 测试 forward 嵌套转发（3层）
- [x] 测试 buntdb sorted set 重启后索引恢复
- [x] 测试 video/file 本地文件转发

🤖 Generated with [Claude Code](https://claude.com/claude-code)