### PR TITLE
fix(youtube): add VideoKey TTL, YtLive/YtFirstLive filters, drop dead code

### DIFF
--- a/lsp/youtube/concern.go
+++ b/lsp/youtube/concern.go
@@ -52,7 +52,10 @@ func (c *Concern) Add(ctx mmsg.IMsgCtx, groupCode int64, _id interface{}, ctype 
 		return nil, fmt.Errorf("查询channel信息失败 %v - %v", id, err)
 	}
 	for _, v := range info.VideoInfo {
-		c.StateManager.AddVideo(v)
+		if err := c.StateManager.AddVideo(v); err != nil {
+			log.WithError(err).WithField("video_id", v.VideoId).
+				Warn("youtube: AddVideo failed during Add()")
+		}
 	}
 	_, err = c.StateManager.AddGroupConcern(groupCode, id, ctype)
 	if err != nil {
@@ -296,7 +299,10 @@ func (c *Concern) FindInfo(channelId string, load bool, addMode bool) (*Info, er
 			return nil, err
 		}
 		info = NewInfo(vi, addMode)
-		c.StateManager.AddInfo(info)
+		if err := c.StateManager.AddInfo(info); err != nil {
+			logger.WithField("channel_id", channelId).
+				WithError(err).Warn("youtube: AddInfo failed during FindInfo()")
+		}
 	}
 
 	if info != nil {

--- a/lsp/youtube/config.go
+++ b/lsp/youtube/config.go
@@ -12,11 +12,17 @@ const (
 	YtVideo = "video"
 	// YtShorts represents YouTube Shorts type
 	YtShorts = "shorts"
+	// YtLive matches any live status (live streaming or waiting/premiere).
+	YtLive = "live"
+	// YtFirstLive matches premiere/waiting livestreams only.
+	YtFirstLive = "firstlive"
 )
 
 var PredefinedType = map[string][]VideoType{
-	YtVideo:  {VideoType_Video},
-	YtShorts: {VideoType_Shorts},
+	YtVideo:     {VideoType_Video},
+	YtShorts:    {VideoType_Shorts},
+	YtLive:      {VideoType_Live, VideoType_FirstLive},
+	YtFirstLive: {VideoType_FirstLive},
 }
 
 type GroupConcernConfig struct {
@@ -148,7 +154,7 @@ func CheckTypeDefine(types []string) (invalid []string) {
 		}
 		// Try parsing as int32 VideoType
 		if tp, err := strconv.ParseInt(t, 10, 32); err == nil {
-			if tp >= 0 && tp <= 3 {
+			if tp >= 0 && tp <= int64(VideoType_Shorts) {
 				continue
 			}
 		}

--- a/lsp/youtube/config_test.go
+++ b/lsp/youtube/config_test.go
@@ -141,7 +141,7 @@ func TestGroupConcernConfig_AtBeforeHook(t *testing.T) {
 
 func TestCheckTypeDefine(t *testing.T) {
 	// Known string names should pass.
-	assert.Empty(t, CheckTypeDefine([]string{YtVideo, YtShorts}))
+	assert.Empty(t, CheckTypeDefine([]string{YtVideo, YtShorts, YtLive, YtFirstLive}))
 
 	// Known int values (0..3) should pass — even though some (Live, FirstLive)
 	// aren't mapped in PredefinedType yet, callers may still configure them
@@ -225,6 +225,42 @@ func TestGroupConcernConfig_FilterHook(t *testing.T) {
 		g.GetGroupConcernFilter().SetRule(concern.FilterTypeNotType, `{"type":["shorts"]}`)
 		assert.True(t, g.FilterHook(newNewsInfo(test.NAME1)).Pass)
 		assert.True(t, g.FilterHook(newLiveInfo(test.NAME1, true, true, false)).Pass)
+		assert.False(t, g.FilterHook(newShortsInfo(test.NAME1)).Pass)
+	})
+
+	t.Run("type=live passes live and firstlive, blocks video and shorts", func(t *testing.T) {
+		g := &GroupConcernConfig{IConfig: &concern.GroupConcernConfig{}}
+		g.GetGroupConcernFilter().SetRule(concern.FilterTypeType, `{"type":["live"]}`)
+
+		// Live (actively streaming) passes.
+		assert.True(t, g.FilterHook(newLiveInfo(test.NAME1, true, true, false)).Pass)
+		// FirstLive (premiere/waiting) also passes — YtLive covers both.
+		assert.True(t, g.FilterHook(&ConcernNotify{
+			VideoInfo: &VideoInfo{
+				UserInfo:    UserInfo{ChannelId: test.NAME1},
+				VideoType:   VideoType_FirstLive,
+				VideoStatus: VideoStatus_Waiting,
+			},
+		}).Pass)
+		// Regular video / shorts do not pass.
+		assert.False(t, g.FilterHook(newNewsInfo(test.NAME1)).Pass)
+		assert.False(t, g.FilterHook(newShortsInfo(test.NAME1)).Pass)
+	})
+
+	t.Run("type=firstlive only passes premiere/waiting", func(t *testing.T) {
+		g := &GroupConcernConfig{IConfig: &concern.GroupConcernConfig{}}
+		g.GetGroupConcernFilter().SetRule(concern.FilterTypeType, `{"type":["firstlive"]}`)
+
+		assert.True(t, g.FilterHook(&ConcernNotify{
+			VideoInfo: &VideoInfo{
+				UserInfo:    UserInfo{ChannelId: test.NAME1},
+				VideoType:   VideoType_FirstLive,
+				VideoStatus: VideoStatus_Waiting,
+			},
+		}).Pass)
+		// Active live is NOT a firstlive.
+		assert.False(t, g.FilterHook(newLiveInfo(test.NAME1, true, true, false)).Pass)
+		assert.False(t, g.FilterHook(newNewsInfo(test.NAME1)).Pass)
 		assert.False(t, g.FilterHook(newShortsInfo(test.NAME1)).Pass)
 	})
 

--- a/lsp/youtube/fetchInfo.go
+++ b/lsp/youtube/fetchInfo.go
@@ -877,14 +877,21 @@ func extractShortsTitle(accessibilityText string) string {
 	}
 	// Format is like "忍得住这种酥麻感吗？♡ #shorts #asmr, 7,690次观看 - 播放 Shorts 短视频"
 	// We want everything before the first #shorts or #tag
+	title := accessibilityText
 	if idx := strings.Index(accessibilityText, " #"); idx > 0 {
-		return strings.TrimSpace(accessibilityText[:idx])
+		title = accessibilityText[:idx]
+	} else if idx := strings.Index(accessibilityText, ","); idx > 0 {
+		// Some locales omit the #shorts tag and put a comma before the view count.
+		title = accessibilityText[:idx]
 	}
-	// Also check for comma before view count
-	if idx := strings.Index(accessibilityText, ","); idx > 0 {
-		return strings.TrimSpace(accessibilityText[:idx])
+	title = strings.TrimSpace(title)
+	// Guard against pathological inputs (entire accessibilityText with no
+	// separator at all) — keep the title bounded so templates don't blow up.
+	const maxShortsTitleLen = 200
+	if len(title) > maxShortsTitleLen {
+		title = strings.TrimSpace(title[:maxShortsTitleLen]) + "…"
 	}
-	return accessibilityText
+	return title
 }
 
 func parseHeaderLiveInfo(root *gabs.Container, channelID, channelName string) *VideoInfo {

--- a/lsp/youtube/fetchInfo_test.go
+++ b/lsp/youtube/fetchInfo_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Jeffail/gabs/v2"
@@ -579,6 +580,14 @@ func TestExtractShortsTitle(t *testing.T) {
 			name: "empty input",
 			in:   "",
 			want: "",
+		},
+		{
+			// No separator at all + length way over the cap. The function should
+			// fall back to a hard-truncated title so a pathological accessibilityText
+			// can't blow up the renderer downstream.
+			name: "pathological long input is truncated",
+			in:   strings.Repeat("a", 500),
+			want:  strings.Repeat("a", 200) + "…",
 		},
 	}
 	for _, tt := range tests {

--- a/lsp/youtube/stateManager.go
+++ b/lsp/youtube/stateManager.go
@@ -35,7 +35,9 @@ func (s *StateManager) GetVideo(channelId string, videoId string) (*VideoInfo, e
 }
 
 func (s *StateManager) AddVideo(v *VideoInfo) error {
-	return s.SetJson(s.VideoKey(v.ChannelId, v.VideoId), v)
+	// TTL mirrors AddInfo so an unused VideoKey does not pile up indefinitely
+	// in buntdb; live states are removed via DeleteLiveState when streaming ends.
+	return s.SetJson(s.VideoKey(v.ChannelId, v.VideoId), v, localdb.SetExpireOpt(time.Hour*24*7))
 }
 
 func (s *StateManager) DeleteLiveState(channelId string) error {
@@ -102,26 +104,6 @@ func (s *StateManager) DeleteLiveState(channelId string) error {
 		}
 		return nil
 	})
-}
-
-// getInfoWithoutCache reads info directly from DB without caching layer
-func (s *StateManager) getInfoWithoutCache(channelId string) (*Info, error) {
-	db, err := localdb.GetClient()
-	if err != nil {
-		return nil, err
-	}
-	var info *Info
-	err = db.View(func(tx *buntdb.Tx) error {
-		val, err := tx.Get(s.InfoKey(channelId))
-		if err != nil {
-			return err
-		}
-		return json.Unmarshal([]byte(val), &info)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return info, nil
 }
 
 func (s *StateManager) GetGroupConcernConfig(groupCode int64, id interface{}) (concernConfig concern.IConfig) {


### PR DESCRIPTION
## Summary

Follow-ups from the Shorts PR review (#26) plus a couple of issues flagged after running it for a while.

## Changes

- **StateManager.AddVideo**: 7-day TTL so unused per-video keys don't grow buntdb unbounded. Live states are still removed via DeleteLiveState when the stream ends.
- **PredefinedType**: add YtLive / YtFirstLive so groups can filter live and premiere notifications alongside video/shorts.
- **CheckTypeDefine**: replace the hardcoded 	p <= 3 magic number with a VideoType_Shorts reference so the bound tracks new enum values.
- **Concern.Add / FindInfo**: log (don't swallow) AddVideo and AddInfo errors.
- **Drop unused getInfoWithoutCache** helper (zero call sites).
- **extractShortsTitle**: hard cap at 200 chars to keep pathological accessibilityText inputs from blowing up the renderer.
- Update tests: CheckTypeDefine + FilterHook now cover live/firstlive, and extractShortsTitle covers the truncation path.

## Skipped (with reason)

- Cross-locale title parser - extractShortsTitle is already locale-agnostic.
- contentId fallback - already sufficient.
- XFetchInfo pacing - PR #26 already adds 100-300ms random sleep.
- Template system review - out of scope; will file as a follow-up issue.

## Test plan

- go build ./... clean
- go test -count=1 ./lsp/youtube/... - 15.0s, all green
- 3 new test cases: YtLive filter, YtFirstLive filter, extractShortsTitle truncation