### PR TITLE
feat(weibo): 重构告警通知系统，新增 SUB 过期检测与自动 Cookie 恢复

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -266,6 +266,12 @@ weibo:
   # 可配置为自建的 SnapCast 服务地址
   snapcastURL: ""
 
+  # Cookie 告警通知配置
+  disableCookieAlert: false  # 设为 true 可关闭 Cookie/SUB 失效告警通知
+  alertGroupId: 0            # Cookie 告警发送到指定群，0 表示不发群
+  # alertQQList:             # Cookie 告警私聊发送给指定 QQ（可选，支持数组或逗号分隔字符串）
+  #   - 123456
+
 youtube:
   onlyOnlineNotify: true  # 是否不推送 Bot 离线期间的动态和直播，默认为 false 表示需要推送，设置为 true 表示不推送
 

--- a/lsp/bilibili/bilibili.go
+++ b/lsp/bilibili/bilibili.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Sora233/MiraiGo-Template/config"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/cfg"
 	"github.com/cnxysoft/DDBOT-WSa/proxy_pool"
 	"github.com/cnxysoft/DDBOT-WSa/requests"
 	jsoniter "github.com/json-iterator/go"
@@ -127,9 +128,11 @@ func Init() {
 					}
 					config.GlobalConfig.Set("bilibili.SESSDATA", cookies.SESSDATA)
 					config.GlobalConfig.Set("bilibili.bili_jct", cookies.BILI_JCT)
-					if err := config.GlobalConfig.WriteConfig(); err != nil {
-						logger.Errorf("保存配置文件失败 - %v", err)
-						continue
+					if err := cfg.WriteConfigKeyValue("bilibili.SESSDATA", cookies.SESSDATA); err != nil {
+						logger.Errorf("保存 SESSDATA 到配置文件失败 - %v", err)
+					}
+					if err := cfg.WriteConfigKeyValue("bilibili.bili_jct", cookies.BILI_JCT); err != nil {
+						logger.Errorf("保存 bili_jct 到配置文件失败 - %v", err)
 					}
 					SetVerify(cookies.SESSDATA, cookies.BILI_JCT)
 					FreshSelfInfo()

--- a/lsp/buntdb/key.go
+++ b/lsp/buntdb/key.go
@@ -223,6 +223,9 @@ func XHSUserInfoKey(keys ...interface{}) string {
 func WeiboCookieAlertKey(keys ...interface{}) string {
 	return NamedKey("WeiboCookieAlert", keys)
 }
+func WeiboSUBExpiredAlertKey(keys ...interface{}) string {
+	return NamedKey("WeiboSUBExpiredAlert", keys)
+}
 func TwitterUserInfoKey(keys ...interface{}) string {
 	return NamedKey("TwitterUserInfo", keys)
 }

--- a/lsp/cfg/config.go
+++ b/lsp/cfg/config.go
@@ -202,7 +202,14 @@ func GetTwitchOnlyOnlineNotify() bool {
 func GetWeiboMode() string {
 	mode := strings.TrimSpace(config.GlobalConfig.GetString("weibo.mode"))
 	if mode == "" {
-		mode = "guest"
+		// 未指定模式时，如果已配置 SUB 则自动使用 login 模式
+		sub := strings.TrimSpace(config.GlobalConfig.GetString("weibo.sub"))
+		if sub != "" {
+			mode = "login"
+			logger.Debugf("weibo.mode 未配置，检测到 weibo.sub 已配置，自动使用 login 模式")
+		} else {
+			mode = "guest"
+		}
 		return mode
 	}
 	if mode != "guest" && mode != "login" && mode != "api" {
@@ -240,8 +247,49 @@ func GetWeiboAutoRefresh() bool {
 }
 
 // GetWeiboAlertGroupId 获取 Cookie 告警通知的目标群号，0 表示不发群
+// Deprecated: 新告警逻辑改为通过 /config weibo_alert 逐群控制，此配置项已不再使用
 func GetWeiboAlertGroupId() int64 {
 	return config.GlobalConfig.GetInt64("weibo.alertGroupId")
+}
+
+// GetWeiboCookieAlertEnabled 检查是否启用 Cookie 失效告警通知
+func GetWeiboCookieAlertEnabled() bool {
+	// 默认启用，显式设置为 false 时禁用
+	return !config.GlobalConfig.GetBool("weibo.disableCookieAlert")
+}
+
+// GetWeiboAlertQQList 获取 Cookie 告警通知的 QQ 列表（私聊）
+// 支持两种格式：
+// 1. 数组格式：[123456, 789012]
+// 2. 字符串格式："123456,789012" 或 "123456 789012"
+func GetWeiboAlertQQList() []int64 {
+	var result []int64
+
+	// 尝试从 viper 获取数组
+	list := config.GlobalConfig.GetStringSlice("weibo.alertQQList")
+	if len(list) > 0 {
+		for _, s := range list {
+			if id := cast.ToInt64(s); id > 0 {
+				result = append(result, id)
+			}
+		}
+		return result
+	}
+
+	// 尝试从字符串解析（逗号或空格分隔）
+	str := strings.TrimSpace(config.GlobalConfig.GetString("weibo.alertQQList"))
+	if str == "" {
+		return nil
+	}
+
+	// 替换逗号为空格，然后按空格分割
+	str = strings.ReplaceAll(str, ",", " ")
+	for _, s := range strings.Fields(str) {
+		if id := cast.ToInt64(s); id > 0 {
+			result = append(result, id)
+		}
+	}
+	return result
 }
 
 // GetSnapCastURL 获取 SnapCast 服务地址，用于生成微博 rid

--- a/lsp/cfg/yamlutil.go
+++ b/lsp/cfg/yamlutil.go
@@ -1,0 +1,97 @@
+package cfg
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/Sora233/MiraiGo-Template/config"
+)
+
+var cfgMu sync.Mutex
+
+// WriteConfigKeyValue safely updates a single key in application.yaml.
+// The key uses dot notation (e.g. "weibo.alertGroupId").
+// It performs line-by-line text manipulation to preserve all other content.
+func WriteConfigKeyValue(key, value string) error {
+	cfgMu.Lock()
+	defer cfgMu.Unlock()
+
+	cfgFile := config.GlobalConfig.ConfigFileUsed()
+	if cfgFile == "" {
+		cfgFile = "application.yaml"
+	}
+	data, err := os.ReadFile(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	parts := strings.SplitN(key, ".", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid config key format: %s (expected section.name)", key)
+	}
+	section := parts[0]
+	keyName := parts[1]
+
+	content := string(data)
+	lines := strings.Split(content, "\n")
+
+	var out []string
+	inSection := false
+	indentSection := ""
+	inserted := false
+	keyRe := regexp.MustCompile(`^(\s*)` + regexp.QuoteMeta(keyName) + `:\s*`)
+
+	for i, line := range lines {
+		trim := strings.TrimSpace(line)
+
+		// Detect section header (e.g. "weibo:")
+		if strings.HasPrefix(trim, section+":") && !inSection {
+			inSection = true
+			idx := strings.Index(line, section+":")
+			indentSection = line[:idx]
+			out = append(out, line)
+			continue
+		}
+
+		if inSection {
+			// Exit section: non-indented non-empty line
+			if len(trim) > 0 && !strings.HasPrefix(line, indentSection+" ") && !strings.HasPrefix(line, indentSection+"\t") {
+				// Insert before exiting if not yet inserted
+				if !inserted {
+					out = append(out, fmt.Sprintf("%s  %s: %s", indentSection, keyName, value))
+					inserted = true
+				}
+				inSection = false
+			} else {
+				// Inside section: check for existing key
+				if m := keyRe.FindStringSubmatch(line); m != nil {
+					out = append(out, fmt.Sprintf("%s  %s: %s", indentSection, keyName, value))
+					inserted = true
+					continue
+				}
+			}
+		}
+
+		out = append(out, line)
+
+		// Last line: still in section and not inserted
+		if i == len(lines)-1 && inSection && !inserted {
+			out = append(out, fmt.Sprintf("%s  %s: %s", indentSection, keyName, value))
+			inserted = true
+		}
+	}
+
+	// Section not found: append new section
+	if !inserted {
+		if len(out) > 0 && out[len(out)-1] != "" {
+			out = append(out, "")
+		}
+		out = append(out, section+":")
+		out = append(out, fmt.Sprintf("  %s: %s", keyName, value))
+	}
+
+	return os.WriteFile(cfgFile, []byte(strings.Join(out, "\n")), 0o644)
+}

--- a/lsp/groupCommand.go
+++ b/lsp/groupCommand.go
@@ -744,10 +744,13 @@ func (lgc *LspGroupCommand) ConfigCommand() {
 				Id string `arg:"" help:"配置的主播id"`
 			} `cmd:"" help:"查看当前过滤器" name:"show" group:"filter"`
 		} `cmd:"" help:"配置动态过滤器" name:"filter"`
+		WeiboAlert struct {
+			Action string `arg:"" optional:"" default:"show" enum:"show,true,false,1,0,on,off,enable,disable" help:"show=查看, true/false=群内开关"`
+		} `cmd:"" help:"配置本群是否接收微博Cookie/SUB告警通知" name:"weibo_alert"`
 	}
 
 	kongCtx, output := lgc.parseCommandSyntax(&configCmd, lgc.CommandName(),
-		kong.Description("管理BOT的配置，目前支持配置@成员、@全体成员、开启下播推送、开启标题推送、推送过滤"),
+		kong.Description("管理BOT的配置，目前支持配置@成员、@全体成员、开启下播推送、开启标题推送、推送过滤、微博告警"),
 	)
 	if output != "" {
 		lgc.textReply(output)
@@ -836,9 +839,177 @@ func (lgc *LspGroupCommand) ConfigCommand() {
 			log.WithField("filter_cmd", filterCmd).Errorf("unknown filter command")
 			lgc.textSend("未知的filter子命令")
 		}
+	case "weibo_alert":
+		lgc.ConfigWeiboAlertCommand(configCmd.WeiboAlert.Action)
 	default:
 		lgc.textSend("暂未支持，你可以催作者GKD")
 	}
+}
+
+// ConfigWeiboAlertCommand 配置微博告警通知发送对象
+// 群内使用：/config weibo_alert true|false|show 控制该群是否接收告警
+func (lgc *LspGroupCommand) ConfigWeiboAlertCommand(action string) {
+	log := lgc.DefaultLoggerWithCommand("config weibo_alert")
+	log.Infof("run config weibo_alert command")
+	defer func() { log.Infof("config weibo_alert command end") }()
+
+	// 需要管理员权限
+	if !lgc.l.PermissionStateManager.RequireAny(
+		permission.AdminRoleRequireOption(lgc.uin()),
+	) {
+		lgc.textReply("权限不足 - 需要管理员权限")
+		return
+	}
+
+	groupCode := lgc.groupCode()
+
+	if groupCode > 0 {
+		// 群内使用：切换该群的告警开关
+		lgc.configWeiboAlertGroup(action, groupCode)
+	} else {
+		// 私聊使用 show 时，显示当前设置
+		lgc.configWeiboAlertPrivate(action, 0, 0)
+	}
+}
+
+// configWeiboAlertGroup 群内配置微博告警开关
+func (lgc *LspGroupCommand) configWeiboAlertGroup(action string, groupCode int64) {
+	switch action {
+	case "true", "1", "on", "enable":
+		if err := weibo.EnableAlertGroup(groupCode); err != nil {
+			lgc.textReply("启用失败")
+			return
+		}
+		lgc.textReply(fmt.Sprintf("已为本群（%d）启用微博 Cookie/SUB 告警通知", groupCode))
+
+	case "false", "0", "off", "disable":
+		if err := weibo.DisableAlertGroup(groupCode); err != nil {
+			lgc.textReply("禁用失败")
+			return
+		}
+		lgc.textReply(fmt.Sprintf("已为本群（%d）禁用微博 Cookie/SUB 告警通知", groupCode))
+
+	case "show":
+		enabled := weibo.IsAlertGroupEnabled(groupCode)
+		if enabled {
+			lgc.textReply(fmt.Sprintf("本群（%d）已启用微博 Cookie/SUB 告警通知", groupCode))
+		} else {
+			lgc.textReply(fmt.Sprintf("本群（%d）未启用微博 Cookie/SUB 告警通知\n发送 /config weibo_alert true 可开启", groupCode))
+		}
+
+	default:
+		lgc.textReply("群内用法：/config weibo_alert true|false|show\ntrue=开启本群告警, false=关闭本群告警, show=查看状态")
+	}
+}
+
+// configWeiboAlertPrivate 私聊配置微博告警目标
+func (lgc *LspGroupCommand) configWeiboAlertPrivate(action string, group, qq int64) {
+	handleWeiboAlertPrivate(func(s string) { lgc.textReply(s) }, action, group, qq)
+}
+
+// handleWeiboAlertPrivate 私聊配置微博告警目标（独立函数，供群聊和私聊命令共用）
+func handleWeiboAlertPrivate(reply func(string), action string, group, qq int64) {
+	key := localdb.Key("WeiboAlertTarget")
+
+	switch action {
+	case "show":
+		var lines []string
+		lines = append(lines, "=== 微博告警推送目标 ===")
+
+		// 管理员私聊（默认）
+		admins := weibo.GetBotAdmins()
+		if len(admins) > 0 {
+			lines = append(lines, "")
+			lines = append(lines, "【私聊 - 管理员】")
+			for _, qq := range admins {
+				lines = append(lines, fmt.Sprintf("  QQ %d", qq))
+			}
+		} else {
+			lines = append(lines, "")
+			lines = append(lines, "【私聊 - 管理员】（无）")
+		}
+
+		// 已启用告警的群
+		alertGroups := weibo.GetEnabledAlertGroups()
+		if len(alertGroups) > 0 {
+			lines = append(lines, "")
+			lines = append(lines, "【群聊 - 已启用告警】")
+			for _, gc := range alertGroups {
+				lines = append(lines, fmt.Sprintf("  群 %d", gc))
+			}
+		} else {
+			lines = append(lines, "")
+			lines = append(lines, "【群聊 - 已启用告警】（无）")
+		}
+
+		// 自定义目标
+		val, err := localdb.Get(key)
+		if err == nil {
+			lines = append(lines, "")
+			lines = append(lines, fmt.Sprintf("【自定义目标】%s", formatAlertTarget(val)))
+		}
+
+		lines = append(lines, "")
+		lines = append(lines, "在群内发送 /config weibo_alert true 可为该群启用告警")
+		reply(strings.Join(lines, "\n"))
+
+	case "clear":
+		_, err := localdb.Delete(key)
+		if err != nil && !localdb.IsNotFound(err) {
+			reply("清除失败")
+		} else {
+			reply("已清除自定义微博告警目标\n将恢复默认行为：私聊发送给所有管理员")
+		}
+
+	case "set":
+		if group <= 0 && qq <= 0 {
+			reply("请指定告警目标\n用法：/config weibo_alert set -g 群号 或 -q QQ号")
+			return
+		}
+
+		if group > 0 && qq > 0 {
+			reply("不能同时指定群和QQ，请只使用其中一个参数")
+			return
+		}
+
+		var alertType string
+		var alertID int64
+
+		if group > 0 {
+			alertType = "group"
+			alertID = group
+		} else {
+			alertType = "private"
+			alertID = qq
+		}
+
+		value := fmt.Sprintf("%s:%d", alertType, alertID)
+		err := localdb.Set(key, value)
+		if err != nil {
+			reply("设置失败")
+			return
+		}
+
+		if alertType == "group" {
+			reply(fmt.Sprintf("已设置微博告警目标为群 %d\nCookie/SUB告警将发送到该群", alertID))
+		} else {
+			reply(fmt.Sprintf("已设置微博告警目标为 QQ %d\nCookie/SUB告警将私聊发送给该用户", alertID))
+		}
+
+	default:
+		reply("私聊用法：/config weibo_alert set -g 群号 | set -q QQ号 | show | clear\n在群内使用 /config weibo_alert true 可为该群启用告警")
+	}
+}
+
+func formatAlertTarget(val string) string {
+	parts := strings.SplitN(val, ":", 2)
+	if len(parts) != 2 {
+		return val
+	}
+	if parts[0] == "group" {
+		return fmt.Sprintf("群 %s（群聊）", parts[1])
+	}
+	return fmt.Sprintf("QQ %s（私聊）", parts[1])
 }
 
 func (lgc *LspGroupCommand) ReverseCommand() {

--- a/lsp/privateCommand.go
+++ b/lsp/privateCommand.go
@@ -407,6 +407,11 @@ func (c *LspPrivateCommand) ConfigCommand() {
 				Id string `arg:"" help:"配置的主播id"`
 			} `cmd:"" help:"查看当前过滤器" name:"show" group:"filter"`
 		} `cmd:"" help:"配置动态过滤器" name:"filter"`
+		WeiboAlert struct {
+			Action string `arg:"" optional:"" default:"show" enum:"set,clear,show" help:"set=设置告警目标, clear=清除, show=查看当前设置"`
+			Group  int64  `optional:"" short:"g" help:"告警发送到指定群"`
+			QQ     int64  `optional:"" short:"q" help:"告警私聊发送给指定QQ"`
+		} `cmd:"" help:"配置微博Cookie/SUB告警通知的发送对象" name:"weibo_alert"`
 		Group int64 `optional:"" short:"g" help:"要操作的QQ群号码"`
 	}
 
@@ -421,14 +426,18 @@ func (c *LspPrivateCommand) ConfigCommand() {
 	}
 
 	groupCode := configCmd.Group
-	if err := c.checkGroupCode(groupCode); err != nil {
-		c.textReply(err.Error())
-		return
-	}
 
 	kongPath := strings.Split(kongCtx.Command(), " ")
 
 	cmd := kongPath[0]
+
+	// weibo_alert 不需要群号校验，其他子命令需要
+	if cmd != "weibo_alert" {
+		if err := c.checkGroupCode(groupCode); err != nil {
+			c.textReply(err.Error())
+			return
+		}
+	}
 	log = log.WithFields(localutils.GroupLogFields(groupCode)).WithField("sub_command", cmd)
 
 	switch cmd {
@@ -506,6 +515,8 @@ func (c *LspPrivateCommand) ConfigCommand() {
 			log.WithField("filter_cmd", filterCmd).Errorf("unknown filter command")
 			c.textSend("未知的filter子命令")
 		}
+	case "weibo_alert":
+		handleWeiboAlertPrivate(func(s string) { c.textSend(s) }, configCmd.WeiboAlert.Action, configCmd.WeiboAlert.Group, configCmd.WeiboAlert.QQ)
 	default:
 		c.textSend("暂未支持，你可以催作者GKD")
 	}

--- a/lsp/weibo/concern.go
+++ b/lsp/weibo/concern.go
@@ -92,6 +92,8 @@ func (c *Concern) Start() error {
 				}
 				sub = obtained
 				logger.Infof("扫码登录成功，已获取 SUB。请写入 application.yaml -> weibo.sub 以便下次启动：%s", sub)
+				// 扫码成功后立即加载 Cookie 到内存
+				freshCookieOpt(sub)
 			}
 
 			// 如果仍然没有 SUB，模块关闭
@@ -120,23 +122,41 @@ func (c *Concern) Start() error {
 		StartSubAutoRefresh()
 	}
 
+	// 启动时立即刷新一次 Cookie（配置已加载，可以正确判断模式）
+	if !isAPI {
+		cookieHealthy.Store(false)
+		ForceFreshCookie()
+	}
+
 	if !isGuest && !isAPI {
 		// 测试微博 cookie 是否有效，并显示登录信息
 		go func() {
 			// 等待 cookie 刷新完成
 			time.Sleep(2 * time.Second)
 
-			// 微博没有直接获取当前登录用户信息的 API
-			// 通过访问一个测试用户页面来验证 cookie 有效性
 			testUid := int64(5462373877) // 捞穹苍的信息试试 [doge]
+
+			// 先测试 Profile API
 			profileResp, err := ApiContainerGetIndexProfile(testUid)
 			if err != nil {
-				logger.Errorf("微博 Cookie 验证失败 - %v，微博功能可能无法正常使用", err)
+				logger.Errorf("微博 Cookie 验证失败 - Profile API: %v，微博功能可能无法正常使用", err)
 				return
 			}
 
 			if profileResp.GetOk() != 1 {
-				logger.Errorf("微博 Cookie 验证失败 - 接口返回错误码：%v，微博功能可能无法正常使用", profileResp.GetOk())
+				logger.Errorf("微博 Cookie 验证失败 - Profile API 返回错误码: %v，微博功能可能无法正常使用", profileResp.GetOk())
+				return
+			}
+
+			// 再测试 Cards API（获取微博列表），这个 API 需要有效的登录 Cookie
+			cardsResp, err := ApiContainerGetIndexCards(testUid)
+			if err != nil {
+				logger.Errorf("微博 Cookie 验证失败 - Cards API: %v，Cookie 可能已失效", err)
+				return
+			}
+
+			if cardsResp.GetOk() != 1 {
+				logger.Errorf("微博 Cookie 验证失败 - Cards API 返回错误码: %v，Cookie 可能已失效", cardsResp.GetOk())
 				return
 			}
 
@@ -386,6 +406,8 @@ func (c *Concern) notifyGenerator() concern.NotifyGeneratorFunc {
 				}
 			}
 		case *CookieAlertNotify:
+			result = append(result, news)
+		case *SUBExpiredNotify:
 			result = append(result, news)
 		}
 		return result

--- a/lsp/weibo/containerGetIndex.go
+++ b/lsp/weibo/containerGetIndex.go
@@ -100,58 +100,49 @@ func ApiContainerGetIndexCards(uid int64) (*ApiContainerGetIndexCardsResponse, e
 }
 
 func apiContainerGetIndexCardsLogin(uid int64) (*ApiContainerGetIndexCardsResponse, error) {
-	// 获取 CookieOption
 	cookieOpts := CookieOption()
-	if len(cookieOpts) == 0 {
-		logger.Warnf("uid=%d: CookieOption 为空，未加载任何 Cookie", uid)
-	} else {
-		subValue := requests.ExtractCookieOption(cookieOpts, "SUB")
-		if subValue != "" {
-			logger.Debugf("uid=%d: 使用 SUB=%s...", uid, subValue[:min(20, len(subValue))])
-		} else {
-			logger.Warnf("uid=%d: CookieOption 中未找到 SUB", uid)
-		}
-	}
-
-	// 构建请求选项：先添加基础选项
 	opts := buildRequestOptions(CreateReferer(uid))
-
-	// 然后添加 Cookie
 	opts = append(opts, cookieOpts...)
-
-	// 最后从完整的 opts 中提取 XSRF-TOKEN（这样就能从 Cookie 中提取了）
 	opts = append(opts, SetXsrfToken(opts))
-
-	// 调试：打印使用的 XSRF-TOKEN
-	xsrfToken := requests.ExtractCookieOption(cookieOpts, "XSRF-TOKEN")
-	if xsrfToken != "" {
-		logger.Debugf("uid=%d: 使用 XSRF-TOKEN=%s", uid, xsrfToken)
-	} else {
-		logger.Warnf("uid=%d: 未找到 XSRF-TOKEN", uid)
-	}
 
 	profileResp := new(ApiContainerGetIndexCardsResponse)
 	err := requests.Get(PathContainerGetIndex_Cards_Login, CreateParam(uid), &profileResp, opts...)
 	if err != nil {
-		markCookieUnhealthy(err)
-		logger.Errorf("uid=%d: 请求失败 - %v", uid, err)
-
-		var rawResp map[string]interface{}
-		rawErr := requests.Get(PathContainerGetIndex_Cards_Login, CreateParam(uid), &rawResp, opts...)
-		if rawErr != nil {
-			logger.Warnf("uid=%d: 无法解析为 JSON，可能返回了 HTML", uid)
+		// 检测是否是 Cookie 失效（返回 HTML）
+		if isCookieFailure(err) {
+			logger.Warnf("uid=%d: 检测到 Cookie 失效，尝试刷新会话 cookie", uid)
+			if RefreshSessionCookie() {
+				// 刷新成功，重新构建请求并重试
+				cookieOpts = CookieOption()
+				opts = buildRequestOptions(CreateReferer(uid))
+				opts = append(opts, cookieOpts...)
+				opts = append(opts, SetXsrfToken(opts))
+				profileResp = new(ApiContainerGetIndexCardsResponse)
+				err = requests.Get(PathContainerGetIndex_Cards_Login, CreateParam(uid), &profileResp, opts...)
+				if err != nil {
+					// 刷新后仍失败，可能是 SUB 过期
+					if isCookieFailure(err) {
+						logger.Errorf("uid=%d: 会话 cookie 刷新后仍返回 HTML，SUB 可能已过期", uid)
+						NotifySUBExpired()
+					} else {
+						logger.Errorf("uid=%d: 刷新后重试仍失败: %v", uid, err)
+					}
+					markCookieUnhealthy(err)
+					return nil, err
+				}
+				logger.Infof("uid=%d: Cookie 刷新后重试成功", uid)
+			} else {
+				// 刷新失败，可能是 SUB 过期
+				logger.Errorf("uid=%d: 会话 cookie 刷新失败，SUB 可能已过期", uid)
+				NotifySUBExpired()
+				markCookieUnhealthy(err)
+				return nil, err
+			}
+		} else {
+			markCookieUnhealthy(err)
+			logger.Errorf("uid=%d: 请求失败 - %v", uid, err)
+			return nil, err
 		}
-
-		// 如果是 API 模式且请求失败，提示用户检查 baseURL 配置
-		if cfg.IsWeiboAPIMode() {
-			logger.Warnf("uid=%d: API 模式请求失败，请检查 apiModeBaseURL 配置是否正确", uid)
-		}
-		return nil, err
-	}
-
-	// 调试：检查返回的 OK 状态
-	if profileResp.GetOk() != 1 {
-		logger.Warnf("uid=%d: API 返回非成功状态 ok=%d", uid, profileResp.GetOk())
 	}
 
 	return profileResp, nil
@@ -271,10 +262,10 @@ func (r *WeiboMobileProfileResponse) ToProfileResponse() *ApiContainerGetIndexPr
 	data := &ApiContainerGetIndexProfileResponse_Data{}
 	if r.Data.UserInfo != nil {
 		data.User = &ApiContainerGetIndexProfileResponse_Data_UserInfo{
-			Id:               r.Data.UserInfo.Id,
-			ScreenName:       r.Data.UserInfo.ScreenName,
-			ProfileImageUrl:  r.Data.UserInfo.ProfileImageUrl,
-			ProfileUrl:       r.Data.UserInfo.ProfileUrl,
+			Id:              r.Data.UserInfo.Id,
+			ScreenName:      r.Data.UserInfo.ScreenName,
+			ProfileImageUrl: r.Data.UserInfo.ProfileImageUrl,
+			ProfileUrl:      r.Data.UserInfo.ProfileUrl,
 		}
 	}
 	resp.Data = data
@@ -320,17 +311,17 @@ func (r *MobileMblog) ToCard() *Card {
 		return nil
 	}
 	card := &Card{
-		Id:        int64StrToInt64(r.Id),
-		Mid:       r.Mid,
-		Text:      r.Text,
+		Id:         int64StrToInt64(r.Id),
+		Mid:        r.Mid,
+		Text:       r.Text,
 		TextLength: r.TextLength,
-		RawText:   r.RawText,
-		CreatedAt: r.CreatedAt,
-		User:      r.User.ToUserInfo(),
-		Mblogid:   r.Mblogid,
-		Mblogtype: CardType(r.Mblogtype),
-		PicIds:    r.PicIds,
-		PageInfo:  toCardPageInfo(r.PageInfo),
+		RawText:    r.RawText,
+		CreatedAt:  r.CreatedAt,
+		User:       r.User.ToUserInfo(),
+		Mblogid:    r.Mblogid,
+		Mblogtype:  CardType(r.Mblogtype),
+		PicIds:     r.PicIds,
+		PageInfo:   toCardPageInfo(r.PageInfo),
 	}
 	if r.Visible != nil {
 		card.Visible = &Card_Visible{
@@ -360,9 +351,9 @@ func extractPicsToPicInfos(v *structpb.Value) map[string]*Card_PicInfo {
 		return nil
 	}
 	var pics []struct {
-		Pid  string `json:"pid"`
-		Url  string `json:"url"`
-		Size string `json:"size"`
+		Pid   string `json:"pid"`
+		Url   string `json:"url"`
+		Size  string `json:"size"`
 		Large *struct {
 			Url string `json:"url"`
 		} `json:"large"`

--- a/lsp/weibo/freshCookie.go
+++ b/lsp/weibo/freshCookie.go
@@ -317,11 +317,15 @@ func FreshCookieLogin() ([]*http.Cookie, error) {
 		panic(fmt.Sprintf("path %v url parse error", pathPassportGenvisitorProd))
 	}
 	cookies := jar.Cookies(cookieUrl)
-	for _, cookie := range jar.Cookies(baseUrl) {
-		if cookie.Name == "XSRF-TOKEN" || cookie.Name == "WBPSESS" {
-			cookies = append(cookies, cookie)
+
+	// 从 weibo.com 获取 XSRF-TOKEN 和 WBPSESS
+	weiboCookies := jar.Cookies(baseUrl)
+	for _, c := range weiboCookies {
+		if c.Name == "XSRF-TOKEN" || c.Name == "WBPSESS" {
+			cookies = append(cookies, c)
 		}
 	}
+
 	return cookies, nil
 }
 
@@ -401,6 +405,14 @@ func ForceFreshCookie() bool {
 	existingSUB := extractCookieValue(currentOpts, "SUB")
 	existingXSRF := extractCookieValue(currentOpts, "XSRF-TOKEN")
 
+	// 如果内存中没有 SUB，尝试从配置中读取
+	if existingSUB == "" {
+		existingSUB = GetSettingCookie()
+		if existingSUB != "" {
+			logger.Debugf("从配置中读取到 SUB")
+		}
+	}
+
 	cookies, err := FreshCookieLogin()
 	if err != nil {
 		fails := consecutiveCookieFails.Inc()
@@ -451,6 +463,47 @@ func ForceFreshCookie() bool {
 
 func extractCookieValue(opts []requests.Option, name string) string {
 	return requests.ExtractCookieOption(opts, name)
+}
+
+// RefreshSessionCookie 刷新会话 cookie（XSRF-TOKEN、WBPSESS 等），保留 SUB
+// 用于 Cookie 失效时自动恢复，不影响用户登录状态
+func RefreshSessionCookie() bool {
+	refreshMu.Lock()
+	defer refreshMu.Unlock()
+
+	// 获取当前的 SUB
+	currentOpts := CookieOption()
+	existingSUB := extractCookieValue(currentOpts, "SUB")
+	if existingSUB == "" {
+		existingSUB = GetSettingCookie()
+	}
+	if existingSUB == "" {
+		logger.Warn("RefreshSessionCookie: 无可用的 SUB，跳过刷新")
+		return false
+	}
+
+	// 获取新的会话 cookie
+	cookies, err := FreshCookieLogin()
+	if err != nil {
+		logger.Errorf("RefreshSessionCookie: FreshCookieLogin 失败: %v", err)
+		return false
+	}
+
+	// 构建新的 cookie 选项，保留 SUB
+	var opt []requests.Option
+	for _, cookie := range cookies {
+		if cookie.Name == "SUB" {
+			// 跳过 FreshCookieLogin 返回的 SUB（如果有），使用现有的
+			continue
+		}
+		opt = append(opt, requests.CookieOption(cookie.Name, cookie.Value))
+	}
+	// 添加保留的 SUB
+	opt = append(opt, requests.CookieOption("SUB", existingSUB))
+
+	visitorCookiesOpt.Store(opt)
+	logger.Infof("会话 cookie 已刷新，保留 SUB，共加载 %d 个 cookie", len(opt))
+	return true
 }
 
 // PauseRefreshOnRateLimit 当触发 -100（频率限制）时暂停刷新

--- a/lsp/weibo/init.go
+++ b/lsp/weibo/init.go
@@ -24,10 +24,6 @@ func init() {
 	c = NewConcern(concern.GetNotifyChan())
 	concern.RegisterConcern(c)
 
-	// 启动时立即刷新一次 Cookie
-	cookieHealthy.Store(false)
-	ForceFreshCookie()
-
 	// 每 5 分钟检查 Cookie 健康状态，异常时向所有订阅群发送告警
 	go func() {
 		var lastAlertSent bool
@@ -62,8 +58,11 @@ func init() {
 				lastAlertSent = false
 			} else if !lastAlertSent {
 				// 刷新失败且尚未发过告警，发送告警通知
-				sendCookieAlertToAllGroups(false)
-				lastAlertSent = true
+				// 检查是否启用了 Cookie 告警通知
+				if cfg.GetWeiboCookieAlertEnabled() {
+					sendCookieAlertToAllGroups(false)
+					lastAlertSent = true
+				}
 			}
 		}
 	}()
@@ -175,28 +174,36 @@ func getBotAdmins() []int64 {
 	return admins
 }
 
-// sendCookieAlertToAllGroups 发送 Cookie 告警/恢复通知
-// 优先级：bot 管理员私聊 > weibo.alertGroupId（群发）> 不发送
-func sendCookieAlertToAllGroups(isRecovery bool) {
+// broadcastAlertToAllTargets 广播告警到所有目标（管理员私聊 + 已启用告警的群）
+func broadcastAlertToAllTargets(sendPrivate func(qq int64), sendGroup func(groupCode int64)) {
 	admins := getBotAdmins()
-
-	if len(admins) > 0 {
-		for _, qq := range admins {
-			sendPrivateAlert(qq, isRecovery)
-		}
-		return
+	for _, qq := range admins {
+		sendPrivate(qq)
 	}
-
-	// 没有管理员，尝试群发
-	groupCode := cfg.GetWeiboAlertGroupId()
-	if groupCode > 0 {
-		sendGroupAlert(groupCode, isRecovery)
-	} else {
-		logger.Debug("未找到 bot 管理员且 weibo.alertGroupId 未配置，跳过 Cookie 告警通知")
+	alertGroups := getEnabledAlertGroups()
+	for _, groupCode := range alertGroups {
+		sendGroup(groupCode)
+	}
+	if len(admins) == 0 && len(alertGroups) == 0 {
+		logger.Debug("无 bot 管理员且无启用告警的群，跳过告警通知")
 	}
 }
 
+// sendCookieAlertToAllGroups 发送 Cookie 告警/恢复通知
+// 默认私聊发送给管理员，同时发送给已启用告警的群（通过 /config weibo_alert true 开启）
+func sendCookieAlertToAllGroups(isRecovery bool) {
+	if !cfg.GetWeiboCookieAlertEnabled() {
+		logger.Debug("微博 Cookie 告警通知已禁用（weibo.disableCookieAlert=true）")
+		return
+	}
+	broadcastAlertToAllTargets(
+		func(qq int64) { sendPrivateAlert(qq, isRecovery) },
+		func(groupCode int64) { sendGroupAlert(groupCode, isRecovery) },
+	)
+}
+
 // sendPrivateAlert 私聊发送 Cookie 告警
+// 使用 -qq 作为 key，避免与群号冲突（群号为正数）
 func sendPrivateAlert(qq int64, isRecovery bool) {
 	alertKey := c.StateManager.CookieAlertKey(-qq)
 	if !isRecovery {
@@ -242,4 +249,159 @@ func sendGroupAlert(groupCode int64, isRecovery bool) {
 	logger.WithField("GroupCode", groupCode).
 		WithField("IsRecovery", isRecovery).
 		Info("已发送微博 Cookie 告警通知")
+}
+
+// NotifySUBExpired 发送 SUB 过期告警通知
+// 默认私聊发送给管理员，同时发送给已启用告警的群
+func NotifySUBExpired() {
+	if !cfg.GetWeiboCookieAlertEnabled() {
+		logger.Debug("微博告警通知已禁用（weibo.disableCookieAlert=true）")
+		return
+	}
+	broadcastAlertToAllTargets(
+		sendSUBExpiredAlert,
+		sendSUBExpiredGroupAlert,
+	)
+}
+
+// getEnabledAlertGroups 从数据库读取所有已启用告警的群列表
+func getEnabledAlertGroups() []int64 {
+	val, err := localdb.Get(localdb.Key("WeiboAlertGroups"))
+	if err != nil || val == "" {
+		return nil
+	}
+	var groups []int64
+	for _, s := range strings.Split(val, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		groupCode, err := strconv.ParseInt(s, 10, 64)
+		if err == nil && groupCode > 0 {
+			groups = append(groups, groupCode)
+		}
+	}
+	return groups
+}
+
+// enableAlertGroup 启用指定群的 Cookie 告警通知
+func enableAlertGroup(groupCode int64) error {
+	return localdb.RWCover(func() error {
+		groups := getEnabledAlertGroups()
+		for _, g := range groups {
+			if g == groupCode {
+				return nil // 已启用
+			}
+		}
+		groups = append(groups, groupCode)
+		strs := make([]string, len(groups))
+		for i, g := range groups {
+			strs[i] = strconv.FormatInt(g, 10)
+		}
+		return localdb.Set(localdb.Key("WeiboAlertGroups"), strings.Join(strs, ","))
+	})
+}
+
+// disableAlertGroup 禁用指定群的 Cookie 告警通知
+func disableAlertGroup(groupCode int64) error {
+	return localdb.RWCover(func() error {
+		groups := getEnabledAlertGroups()
+		var filtered []int64
+		for _, g := range groups {
+			if g != groupCode {
+				filtered = append(filtered, g)
+			}
+		}
+		if len(filtered) == 0 {
+			_, _ = localdb.Delete(localdb.Key("WeiboAlertGroups"))
+			return nil
+		}
+		strs := make([]string, len(filtered))
+		for i, g := range filtered {
+			strs[i] = strconv.FormatInt(g, 10)
+		}
+		return localdb.Set(localdb.Key("WeiboAlertGroups"), strings.Join(strs, ","))
+	})
+}
+
+// isAlertGroupEnabled 检查指定群是否启用了 Cookie 告警通知
+func isAlertGroupEnabled(groupCode int64) bool {
+	for _, g := range getEnabledAlertGroups() {
+		if g == groupCode {
+			return true
+		}
+	}
+	return false
+}
+
+// EnableAlertGroup 启用指定群的 Cookie 告警通知（供外部调用）
+func EnableAlertGroup(groupCode int64) error {
+	return enableAlertGroup(groupCode)
+}
+
+// DisableAlertGroup 禁用指定群的 Cookie 告警通知（供外部调用）
+func DisableAlertGroup(groupCode int64) error {
+	return disableAlertGroup(groupCode)
+}
+
+// IsAlertGroupEnabled 检查指定群是否启用了 Cookie 告警通知（供外部调用）
+func IsAlertGroupEnabled(groupCode int64) bool {
+	return isAlertGroupEnabled(groupCode)
+}
+
+// GetBotAdmins 获取所有 bot 管理员 QQ（供外部调用）
+func GetBotAdmins() []int64 {
+	return getBotAdmins()
+}
+
+// GetEnabledAlertGroups 获取所有已启用告警的群列表（供外部调用）
+func GetEnabledAlertGroups() []int64 {
+	return getEnabledAlertGroups()
+}
+
+// trySetAlertDedup 尝试设置告警去重 key，返回 true 表示可以发送告警
+func trySetAlertDedup(alertKey string) bool {
+	err := c.StateManager.Set(alertKey, "",
+		localdb.SetExpireOpt(time.Hour*24), localdb.SetNoOverWriteOpt())
+	if err != nil {
+		if localdb.IsRollback(err) {
+			logger.Debug("SUB 过期告警已在 24 小时内发送过，跳过")
+		} else {
+			logger.Errorf("设置 SUB 过期告警状态失败: %v", err)
+		}
+		return false
+	}
+	return true
+}
+
+// sendSUBExpiredAlert 私聊发送 SUB 过期告警
+// 使用 -qq 作为 key，避免与群号冲突（群号为正数）
+func sendSUBExpiredAlert(qq int64) {
+	if !trySetAlertDedup(c.StateManager.SUBExpiredAlertKey(-qq)) {
+		return
+	}
+
+	notify := NewSUBExpiredNotify(0)
+	m := notify.ToMessage()
+	sm := m.ToCombineMessage(mmsg.NewPrivateTarget(qq))
+	summary := msgstringer.AdapterMsgToString(sm.Elements)
+
+	if bot.Instance == nil || !bot.Instance.Online.Load() {
+		logger.WithField("QQ", qq).Warn("Bot 未在线，无法发送私聊告警")
+		return
+	}
+	bot.Instance.SendPrivateMessage(qq, sm, summary)
+	logger.WithField("QQ", qq).Info("已发送微博 SUB 过期告警私聊")
+}
+
+// sendSUBExpiredGroupAlert 群发 SUB 过期告警
+func sendSUBExpiredGroupAlert(groupCode int64) {
+	if !trySetAlertDedup(c.StateManager.SUBExpiredAlertKey(groupCode)) {
+		return
+	}
+
+	notify := NewSUBExpiredNotify(groupCode)
+	concern.GetNotifyChan() <- notify
+	logger.WithField("GroupCode", groupCode).
+		Info("已发送微博 SUB 过期告警通知")
 }

--- a/lsp/weibo/keyset.go
+++ b/lsp/weibo/keyset.go
@@ -19,3 +19,8 @@ func (*extraKeySet) MarkMblogIdKey(keys ...interface{}) string {
 func (*extraKeySet) CookieAlertKey(keys ...interface{}) string {
 	return localdb.WeiboCookieAlertKey(keys...)
 }
+
+func (*extraKeySet) SUBExpiredAlertKey(keys ...interface{}) string {
+	return localdb.WeiboSUBExpiredAlertKey(keys...)
+}
+

--- a/lsp/weibo/model.go
+++ b/lsp/weibo/model.go
@@ -495,9 +495,9 @@ func findVideoForMix(Item []*Card_MixMediaInfo_Items, m *mmsg.MSG) {
 
 // CookieAlertNotify Cookie 失效时的告警通知
 type CookieAlertNotify struct {
-	GroupCode   int64
-	Message     string
-	IsRecovery  bool
+	GroupCode  int64
+	Message    string
+	IsRecovery bool
 }
 
 func (n *CookieAlertNotify) Site() string {
@@ -545,5 +545,51 @@ func NewCookieAlertNotify(groupCode int64, isRecovery bool) *CookieAlertNotify {
 		GroupCode:  groupCode,
 		Message:    msg,
 		IsRecovery: isRecovery,
+	}
+}
+
+// SUBExpiredNotify SUB 过期告警通知
+type SUBExpiredNotify struct {
+	GroupCode int64
+}
+
+func (n *SUBExpiredNotify) Site() string {
+	return Site
+}
+
+func (n *SUBExpiredNotify) Type() concern_type.Type {
+	return CookieAlert
+}
+
+func (n *SUBExpiredNotify) GetUid() interface{} {
+	return int64(0)
+}
+
+func (n *SUBExpiredNotify) GetGroupCode() int64 {
+	return n.GroupCode
+}
+
+func (n *SUBExpiredNotify) Logger() *logrus.Entry {
+	return logger.WithFields(logrus.Fields{
+		"Site":      Site,
+		"GroupCode": n.GroupCode,
+	})
+}
+
+func (n *SUBExpiredNotify) ToMessage() *mmsg.MSG {
+	m := mmsg.NewMSG()
+	m.Textf("[微博SUB过期告警]")
+	m.Textf("\n⚠ 检测到微博 SUB（登录凭证）可能已过期")
+	m.Textf("\n微博订阅推送可能无法正常工作")
+	m.Textf("\n请管理员手动重新登录获取新的 SUB")
+	m.Textf("\n可通过以下方式获取：")
+	m.Textf("\n1. 启用 weibo.qrlogin 扫码登录")
+	m.Textf("\n2. 手动配置 weibo.sub")
+	return m
+}
+
+func NewSUBExpiredNotify(groupCode int64) *SUBExpiredNotify {
+	return &SUBExpiredNotify{
+		GroupCode: groupCode,
 	}
 }


### PR DESCRIPTION
- 将 Cookie/SUB 告警从全局 alertGroupId 改为逐群控制，支持 /config weibo_alert 命令
- 新增 SUBExpiredNotify 类型，Cookie 失效且会话刷新失败时触发 SUB 过期告警
- Cookie 失效时自动调用 RefreshSessionCookie 刷新会话 cookie（保留 SUB）
- Cookie 刷新从 init() 移到 concern.Start()，扫码登录后立即加载 Cookie
- weibo mode 未配置时自动检测 SUB 并切换为 login 模式
- 新增 yamlutil.go 实现安全的行级 YAML 配置写入
- bilibili 配置写入改用 WriteConfigKeyValue 避免全量覆写