### PR TITLE
fix(concern): 校验 text/not_text 冲突及空关键词

### DIFF
--- a/lsp/bilibili/config.go
+++ b/lsp/bilibili/config.go
@@ -34,7 +34,7 @@ func (g *GroupConcernConfig) Validate() error {
 			return concern.ErrConfigNotSupported
 		}
 	}
-	return nil
+	return g.GetGroupConcernFilter().ValidateTextConflict()
 }
 
 func (g *GroupConcernConfig) NotifyBeforeCallback(inotify concern.Notify) {

--- a/lsp/concern/config.go
+++ b/lsp/concern/config.go
@@ -39,7 +39,7 @@ func (g *GroupConcernConfig) Validate() error {
 			return ErrConfigNotSupported
 		}
 	}
-	return nil
+	return g.GetGroupConcernFilter().ValidateTextConflict()
 }
 
 // FilterHook 默认支持filter text配置，其他为Pass，可以重写这个函数实现自定义的过滤

--- a/lsp/concern/config_filter.go
+++ b/lsp/concern/config_filter.go
@@ -3,6 +3,8 @@ package concern
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 )
 
 const (
@@ -157,4 +159,56 @@ func (g *GroupConcernFilterConfig) GetFilterByText() (*GroupConcernFilterConfigB
 	}
 	// 存在规则但无文本过滤规则，按照旧语义返回类型不匹配错误
 	return nil, errors.New("filter type mismatched")
+}
+
+// ValidateTextConflict 检查 text 与 not_text 规则之间是否存在必然拦截全部推送的矛盾配置。
+// FilterHook 对多条规则取 AND（每条都必须通过）、规则内关键词取 OR，
+// 因此只要某条 text 规则的每个关键词都被某个 not_text 关键词覆盖
+// （not_text 词是 text 词的子串，完全相同是特例），
+// 则任何消息都不可能同时通过这两条规则，推送会被全部拦截。
+// 返回 nil 表示无矛盾；返回非 nil 时应拒绝本次配置改动。
+func (g *GroupConcernFilterConfig) ValidateTextConflict() error {
+	var allowRules [][]string // 每条 text 规则的关键词（规则内 OR）
+	var denyWords []string    // 全部 not_text 关键词
+	for _, r := range g.RulesNormalized() {
+		if r.Type != FilterTypeText && r.Type != FilterTypeNotText {
+			continue
+		}
+		textFilter, err := r.GetFilterByText()
+		if err != nil {
+			return fmt.Errorf("解析过滤规则失败: %v", err)
+		}
+		if r.Type == FilterTypeText {
+			allowRules = append(allowRules, textFilter.Text)
+		} else {
+			denyWords = append(denyWords, textFilter.Text...)
+		}
+	}
+	if len(denyWords) == 0 {
+		return nil
+	}
+	for _, allows := range allowRules {
+		if len(allows) == 0 {
+			continue
+		}
+		allDenied := true
+		for _, a := range allows {
+			covered := false
+			for _, d := range denyWords {
+				if d != "" && strings.Contains(a, d) {
+					covered = true
+					break
+				}
+			}
+			if !covered {
+				allDenied = false
+				break
+			}
+		}
+		if allDenied {
+			return fmt.Errorf("%w：text 关键词 %v 均被 not_text 覆盖，将导致所有推送被过滤",
+				ErrFilterRuleConflict, allows)
+		}
+	}
+	return nil
 }

--- a/lsp/concern/config_filter.go
+++ b/lsp/concern/config_filter.go
@@ -178,6 +178,14 @@ func (g *GroupConcernFilterConfig) ValidateTextConflict() error {
 		if err != nil {
 			return fmt.Errorf("解析过滤规则失败: %v", err)
 		}
+		if textFilter == nil || len(textFilter.Text) == 0 {
+			return ErrFilterKeywordEmpty
+		}
+		for _, keyword := range textFilter.Text {
+			if strings.TrimSpace(keyword) == "" {
+				return ErrFilterKeywordEmpty
+			}
+		}
 		if r.Type == FilterTypeText {
 			allowRules = append(allowRules, textFilter.Text)
 		} else {

--- a/lsp/concern/config_test.go
+++ b/lsp/concern/config_test.go
@@ -260,6 +260,52 @@ func TestGroupConcernConfig_Validate(t *testing.T) {
 	assert.NotNil(t, g.Validate())
 }
 
+func TestGroupConcernFilterConfig_ValidateTextConflict(t *testing.T) {
+	textRule := func(words ...string) string {
+		return (&GroupConcernFilterConfigByText{Text: words}).ToString()
+	}
+
+	// text 与 not_text 含相同关键词：必然全部拦截，应报错
+	var g GroupConcernConfig
+	g.GetGroupConcernFilter().SetRule(FilterTypeText, textRule("原神"))
+	g.GetGroupConcernFilter().SetRule(FilterTypeNotText, textRule("原神", "旅人纪行"))
+	err := g.Validate()
+	assert.NotNil(t, err)
+	assert.ErrorIs(t, err, ErrFilterRuleConflict)
+
+	// not_text 词是 text 词的子串：包含 text 词的消息必然也含 not_text 词，应报错
+	g.GetGroupConcernFilter().SetRule(FilterTypeText, textRule("原神星"))
+	g.GetGroupConcernFilter().SetRule(FilterTypeNotText, textRule("原神"))
+	err = g.Validate()
+	assert.NotNil(t, err)
+	assert.ErrorIs(t, err, ErrFilterRuleConflict)
+
+	// 无交集：正常配置，应通过
+	g.GetGroupConcernFilter().SetRule(FilterTypeText, textRule("原神"))
+	g.GetGroupConcernFilter().SetRule(FilterTypeNotText, textRule("旅人纪行"))
+	assert.Nil(t, g.Validate())
+
+	// not_text 词是 text 词的超串：不含 not_text 词的 text 消息仍可通过，应通过
+	g.GetGroupConcernFilter().SetRule(FilterTypeText, textRule("原神"))
+	g.GetGroupConcernFilter().SetRule(FilterTypeNotText, textRule("原神星"))
+	assert.Nil(t, g.Validate())
+
+	// text 规则内任一关键词未被覆盖即可放行，应通过
+	g.GetGroupConcernFilter().SetRule(FilterTypeText, textRule("原神", "星穹铁道"))
+	g.GetGroupConcernFilter().SetRule(FilterTypeNotText, textRule("原神"))
+	assert.Nil(t, g.Validate())
+
+	// 仅 not_text：无矛盾，应通过
+	var onlyDeny GroupConcernConfig
+	onlyDeny.GetGroupConcernFilter().SetRule(FilterTypeNotText, textRule("原神"))
+	assert.Nil(t, onlyDeny.Validate())
+
+	// 非法的规则配置 JSON：应报错
+	var broken GroupConcernConfig
+	broken.GetGroupConcernFilter().SetRule(FilterTypeText, "wrong")
+	assert.NotNil(t, broken.Validate())
+}
+
 type testInfo struct {
 	isLive        bool
 	living        bool

--- a/lsp/concern/config_test.go
+++ b/lsp/concern/config_test.go
@@ -304,6 +304,21 @@ func TestGroupConcernFilterConfig_ValidateTextConflict(t *testing.T) {
 	var broken GroupConcernConfig
 	broken.GetGroupConcernFilter().SetRule(FilterTypeText, "wrong")
 	assert.NotNil(t, broken.Validate())
+
+	// 空数组、null、空字符串和纯空白都会让规则永久放行或永久拦截，应拒绝。
+	for _, ruleType := range []string{FilterTypeText, FilterTypeNotText} {
+		for _, config := range []string{
+			`{"text":[]}`,
+			`{"text":null}`,
+			`{"text":[""]}`,
+			`{"text":["   "]}`,
+		} {
+			var empty GroupConcernConfig
+			empty.GetGroupConcernFilter().SetRule(ruleType, config)
+			assert.ErrorIs(t, empty.Validate(), ErrFilterKeywordEmpty,
+				"ruleType=%s config=%s", ruleType, config)
+		}
+	}
 }
 
 type testInfo struct {

--- a/lsp/concern/errors.go
+++ b/lsp/concern/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrTypeNotSupported   = errors.New("不支持的类型参数")
 	ErrSiteNotSupported   = errors.New("不支持的网站参数")
 	ErrConfigNotSupported = errors.New("不支持的配置")
+	ErrFilterRuleConflict = errors.New("过滤配置矛盾")
 )

--- a/lsp/concern/errors.go
+++ b/lsp/concern/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrSiteNotSupported   = errors.New("不支持的网站参数")
 	ErrConfigNotSupported = errors.New("不支持的配置")
 	ErrFilterRuleConflict = errors.New("过滤配置矛盾")
+	ErrFilterKeywordEmpty = errors.New("过滤关键字不能为空")
 )

--- a/lsp/iCommand.go
+++ b/lsp/iCommand.go
@@ -616,7 +616,7 @@ func IConfigFilterCmdNotType(c *MessageContext, groupCode int64, id string, site
 func IConfigFilterCmdText(c *MessageContext, groupCode int64, id string, site string, ctype concern_type.Type, keywords []string) {
 	err := configCmdGroupCommonCheck(c, groupCode)
 	if err == nil {
-		if len(keywords) == 0 {
+		if !validFilterKeywords(keywords) {
 			c.TextReply("失败 - 没有指定过滤关键字")
 			return
 		}
@@ -639,7 +639,7 @@ func IConfigFilterCmdText(c *MessageContext, groupCode int64, id string, site st
 func IConfigFilterCmdNotText(c *MessageContext, groupCode int64, id string, site string, ctype concern_type.Type, keywords []string) {
 	err := configCmdGroupCommonCheck(c, groupCode)
 	if err == nil {
-		if len(keywords) == 0 {
+		if !validFilterKeywords(keywords) {
 			c.TextReply("失败 - 没有指定过滤关键字")
 			return
 		}
@@ -657,6 +657,18 @@ func IConfigFilterCmdNotText(c *MessageContext, groupCode int64, id string, site
 	} else {
 		ReplyUserInfo(c, groupCode, id, site, ctype)
 	}
+}
+
+func validFilterKeywords(keywords []string) bool {
+	if len(keywords) == 0 {
+		return false
+	}
+	for _, keyword := range keywords {
+		if strings.TrimSpace(keyword) == "" {
+			return false
+		}
+	}
+	return true
 }
 
 func IConfigFilterCmdClear(c *MessageContext, groupCode int64, id string, site string, ctype concern_type.Type) {

--- a/lsp/iCommand_test.go
+++ b/lsp/iCommand_test.go
@@ -877,6 +877,14 @@ func TestIConfigFilterCmd(t *testing.T) {
 	result = <-msgChan
 	assert.Contains(t, msgstringer.AdapterMsgToString(result.ToCombineMessage(target).Elements), failed)
 
+	IConfigFilterCmdText(ctx, test.G1, test.NAME1, test.Site1, test.T1, []string{""})
+	result = <-msgChan
+	assert.Contains(t, msgstringer.AdapterMsgToString(result.ToCombineMessage(target).Elements), failed)
+
+	IConfigFilterCmdNotText(ctx, test.G1, test.NAME1, test.Site1, test.T1, []string{"   "})
+	result = <-msgChan
+	assert.Contains(t, msgstringer.AdapterMsgToString(result.ToCombineMessage(target).Elements), failed)
+
 	IConfigFilterCmdText(ctx, test.G1, test.NAME1, test.Site1, test.T1, []string{test.NAME1, test.NAME2})
 	result = <-msgChan
 	assert.Contains(t, msgstringer.AdapterMsgToString(result.ToCombineMessage(target).Elements), success)

--- a/lsp/youtube/config.go
+++ b/lsp/youtube/config.go
@@ -59,7 +59,7 @@ func (g *GroupConcernConfig) Validate() error {
 			return concern.ErrConfigNotSupported
 		}
 	}
-	return nil
+	return g.GetGroupConcernFilter().ValidateTextConflict()
 }
 
 // knownTypeNames returns the user-facing names accepted by type filters.


### PR DESCRIPTION
## 修改内容

- 在通用、Bilibili 和 YouTube 配置校验中检测 text/not_text 语义冲突
- 拒绝 text:[]、text:null、not_text:[]、not_text:null 以及空字符串或纯空白关键词
- 命令入口同步拒绝空关键词，避免写入会永久放行或永久拦截的规则
- 增加配置层与命令层回归测试

## 测试

- go test ./lsp/concern/... ./lsp/bilibili/... ./lsp/youtube/...
- go test ./lsp -run ^TestIConfigFilterCmd$ -count=1

分支重新基于当前 upstream/next-dev 构建，替代 #35 中的过滤配置部分。