### PR TITLE
fix(bilibili): 修复压缩推送缓存与复读问题

### DIFF
--- a/lsp/bilibili/config_test.go
+++ b/lsp/bilibili/config_test.go
@@ -348,36 +348,85 @@ func TestGroupConcernConfig_NotifyBeforeCallback(t *testing.T) {
 	g.NotifyBeforeCallback(live)
 }
 
-func TestGroupConcernConfig_CompactMissAfterFilterCache(t *testing.T) {
-	test.InitBuntdb(t)
-	defer test.CloseBuntdb(t)
-	template.InitTemplateLoader()
-
-	c := initConcern(t)
+func newFilteredCompactVideo(c *Concern, groupCode int64, bvid, action string) (*ConcernNewsNotify, *GroupConcernConfig) {
 	notify := newNewsInfo(test.UID1, DynamicDescType_WithVideo)[0]
-	notify.GroupCode = test.G1
-	notify.Card.Desc.Bvid = test.BVID1
+	notify.GroupCode = groupCode
+	notify.concern = c
+	notify.Card.Desc.Bvid = bvid
+	notify.Card.Desc.UserProfile = &Card_Desc_UserProfile{
+		Info: &Card_Desc_UserProfile_Info{Uname: "投稿用户"},
+	}
+	notify.Card.Display = &Card_Display{
+		UsrActionTxt: action,
+		AddOnCardInfo: []*Card_Display_AddOnCardInfo{
+			{AddOnCardShowType: AddOnCardShowType_match},
+		},
+	}
 
 	baseConfig := new(concern.GroupConcernConfig)
 	baseConfig.GetGroupConcernFilter().SetRule(
 		concern.FilterTypeNotText,
 		(&concern.GroupConcernFilterConfigByText{Text: []string{"never-match"}}).ToString(),
 	)
-	g := NewGroupConcernConfig(baseConfig, c)
+	return notify, NewGroupConcernConfig(baseConfig, c)
+}
+
+func TestGroupConcernConfig_CompactHitAfterFilterCache(t *testing.T) {
+	test.InitBuntdb(t)
+	defer test.CloseBuntdb(t)
+	template.InitTemplateLoader()
+
+	c := initConcern(t)
+	notify, g := newFilteredCompactVideo(c, test.G1, test.BVID1, "联合投稿了视频")
+
+	assert.Nil(t, c.SetGroupCompactMarkIfNotExist(test.G1, test.BVID1))
+	assert.NoError(t, c.SetNotifyMsg(test.BVID1, &adapter.GroupMessage{
+		ID:        1,
+		GroupCode: test.G1,
+		Elements: []adapter.IMessageElement{
+			&adapter.TextSegment{Content: "原消息"},
+		},
+	}))
+	assert.True(t, g.FilterHook(notify).Pass)
+	fullMessage := notify.Card.msgCache
+	assert.NotNil(t, fullMessage)
+	assert.Len(t, notify.Card.dynamic.Addons, 1)
+
+	g.NotifyBeforeCallback(notify)
+	assert.True(t, notify.shouldCompact)
+	compactMessage := notify.ToMessage()
+	assert.False(t, notify.Card.compactMiss)
+	assert.NotSame(t, fullMessage, notify.Card.msgCache)
+	assert.Len(t, notify.Card.dynamic.Addons, 1)
+
+	content := msgstringer.AdapterMsgToString(compactMessage.Elements())
+	assert.Contains(t, content, "投稿用户联合投稿了视频：")
+	assert.NotContains(t, content, "投稿用户转发了的视频：")
+}
+
+func TestGroupConcernConfig_CompactMissAfterFilterCache(t *testing.T) {
+	test.InitBuntdb(t)
+	defer test.CloseBuntdb(t)
+	template.InitTemplateLoader()
+
+	c := initConcern(t)
+	notify, g := newFilteredCompactVideo(c, test.G1, test.BVID1, "发布了动态")
 
 	assert.Nil(t, c.SetGroupCompactMarkIfNotExist(test.G1, test.BVID1))
 	assert.True(t, g.FilterHook(notify).Pass)
 	fullMessage := notify.Card.msgCache
 	assert.NotNil(t, fullMessage)
+	assert.Len(t, notify.Card.dynamic.Addons, 1)
 
 	g.NotifyBeforeCallback(notify)
 	assert.True(t, notify.shouldCompact)
 	compactMessage := notify.ToMessage()
 	assert.True(t, notify.Card.compactMiss)
 	assert.NotSame(t, fullMessage, notify.Card.msgCache)
+	assert.Len(t, notify.Card.dynamic.Addons, 1)
 
 	content := msgstringer.AdapterMsgToString(compactMessage.Elements())
-	assert.Contains(t, content, "投稿了视频")
+	assert.Contains(t, content, "投稿用户发布了动态视频：")
 	assert.NotContains(t, content, "转发了的动态")
 }
 

--- a/lsp/bilibili/config_test.go
+++ b/lsp/bilibili/config_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/cnxysoft/DDBOT-WSa/internal/test"
 	localdb "github.com/cnxysoft/DDBOT-WSa/lsp/buntdb"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/concern"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/template"
+	"github.com/cnxysoft/DDBOT-WSa/utils/msgstringer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -344,6 +346,72 @@ func TestGroupConcernConfig_NotifyBeforeCallback(t *testing.T) {
 
 	live := newLiveInfo(test.UID1, true, false, false)
 	g.NotifyBeforeCallback(live)
+}
+
+func TestGroupConcernConfig_CompactMissAfterFilterCache(t *testing.T) {
+	test.InitBuntdb(t)
+	defer test.CloseBuntdb(t)
+	template.InitTemplateLoader()
+
+	c := initConcern(t)
+	notify := newNewsInfo(test.UID1, DynamicDescType_WithVideo)[0]
+	notify.GroupCode = test.G1
+	notify.Card.Desc.Bvid = test.BVID1
+
+	baseConfig := new(concern.GroupConcernConfig)
+	baseConfig.GetGroupConcernFilter().SetRule(
+		concern.FilterTypeNotText,
+		(&concern.GroupConcernFilterConfigByText{Text: []string{"never-match"}}).ToString(),
+	)
+	g := NewGroupConcernConfig(baseConfig, c)
+
+	assert.Nil(t, c.SetGroupCompactMarkIfNotExist(test.G1, test.BVID1))
+	assert.True(t, g.FilterHook(notify).Pass)
+	fullMessage := notify.Card.msgCache
+	assert.NotNil(t, fullMessage)
+
+	g.NotifyBeforeCallback(notify)
+	assert.True(t, notify.shouldCompact)
+	compactMessage := notify.ToMessage()
+	assert.True(t, notify.Card.compactMiss)
+	assert.NotSame(t, fullMessage, notify.Card.msgCache)
+
+	content := msgstringer.AdapterMsgToString(compactMessage.Elements())
+	assert.Contains(t, content, "投稿了视频")
+	assert.NotContains(t, content, "转发了的动态")
+}
+
+func TestCompactMissTemplateSuppressesCommonFooter(t *testing.T) {
+	template.InitTemplateLoader()
+
+	var dynamic DynamicInfo
+	dynamic.Type = DynamicDescType_WithVideo
+	dynamic.User.Name = "联合投稿用户"
+	dynamic.Video.Action = "联合投稿了视频"
+	dynamic.DynamicUrl = "https://t.bilibili.com/test"
+
+	addon := Addon{Type: AddOnCardShowType(1)}
+	addon.Goods.Name = "不应出现的附加卡片"
+	dynamic.Addons = []Addon{addon}
+	dynamic.Detail.Reserve.Title = "不应出现的预约"
+	dynamic.Detail.Vote = &VoteInfo{Title: "不应出现的投票"}
+
+	msg, err := template.LoadAndExec("notify.group.bilibili.news.tmpl", map[string]interface{}{
+		"dynamic":      dynamic,
+		"msg":          nil,
+		"compact_miss": true,
+		"group_code":   test.G1,
+		"parse_post":   false,
+		"dynamic_raw":  nil,
+	})
+	assert.NoError(t, err)
+	content := msgstringer.AdapterMsgToString(msg.Elements())
+	assert.Contains(t, content, "联合投稿用户联合投稿了视频")
+	assert.Contains(t, content, dynamic.DynamicUrl)
+	assert.NotContains(t, content, "转发了的动态")
+	assert.NotContains(t, content, addon.Goods.Name)
+	assert.NotContains(t, content, dynamic.Detail.Reserve.Title)
+	assert.NotContains(t, content, dynamic.Detail.Vote.Title)
 }
 
 func TestGroupConcernConfig_NotifyAfterCallback(t *testing.T) {

--- a/lsp/bilibili/model.go
+++ b/lsp/bilibili/model.go
@@ -301,7 +301,7 @@ func (notify *ConcernNewsNotify) ToMessage() (m *mmsg.MSG) {
 			msg, err := notify.concern.GetNotifyMsg(notify.GroupCode, notify.compactKey)
 			card.orgMsg = msg
 			card.compactMiss = msg == nil
-			card.resetMessageCache()
+			card.resetRenderCache()
 			notify.compactReady = true
 			if msg == nil {
 				log.WithField("group_code", notify.GroupCode).
@@ -447,12 +447,13 @@ func urlsMergeImage(urls []string) (result []byte, err error) {
 
 type CacheCard struct {
 	*Card
-	GroupCode  int64
-	once       sync.Once
-	msgCache   *mmsg.MSG
-	dynamic    DynamicInfo
-	dynamicRaw map[string]interface{}
-	orgMsg     *adapter.GroupMessage
+	GroupCode   int64
+	prepareOnce sync.Once
+	renderOnce  sync.Once
+	msgCache    *mmsg.MSG
+	dynamic     DynamicInfo
+	dynamicRaw  map[string]interface{}
+	orgMsg      *adapter.GroupMessage
 	// compactMiss 表示本条动态需要紧凑推送（shouldCompact），
 	// 但没能从数据库取到可回复的原消息。
 	// 用于让模板区分「首次推送」与「应压缩却查不到原消息」两种 orgMsg == nil 的情况。
@@ -465,8 +466,8 @@ func NewCacheCard(card *Card) *CacheCard {
 	return cacheCard
 }
 
-func (c *CacheCard) resetMessageCache() {
-	c.once = sync.Once{}
+func (c *CacheCard) resetRenderCache() {
+	c.renderOnce = sync.Once{}
 	c.msgCache = nil
 }
 
@@ -1218,8 +1219,8 @@ func (c *CacheCard) prepare() {
 }
 
 func (c *CacheCard) GetMSG() *mmsg.MSG {
-	c.once.Do(func() {
-		c.prepare()
+	c.prepareOnce.Do(c.prepare)
+	c.renderOnce.Do(func() {
 		var data = map[string]interface{}{
 			"dynamic":      c.dynamic,
 			"msg":          c.orgMsg,

--- a/lsp/bilibili/model.go
+++ b/lsp/bilibili/model.go
@@ -53,6 +53,7 @@ type ConcernNewsNotify struct {
 	// 用于联合投稿和转发的时候防止多人同时推送
 	shouldCompact bool
 	compactKey    string
+	compactReady  bool
 	concern       *Concern
 }
 
@@ -294,18 +295,19 @@ func (notify *ConcernNewsNotify) ToMessage() (m *mmsg.MSG) {
 	)
 	// 推送一条简化动态防止刷屏，主要是联合投稿和转发的时候
 	if notify.shouldCompact {
-		// 通过回复之前消息的方式简化推送
-		m = mmsg.NewMSG()
-		msg, err := notify.concern.GetNotifyMsg(notify.GroupCode, notify.compactKey)
-		if msg != nil {
+		if !notify.compactReady {
+			// FilterHook may already have rendered and cached the full message.
+			// Prepare compact state and invalidate that cache before rendering again.
+			msg, err := notify.concern.GetNotifyMsg(notify.GroupCode, notify.compactKey)
 			card.orgMsg = msg
-		} else {
-			// 取不到原消息（消息未成功入库、缓存过期或数据库错误），
-			// 标记 compactMiss，避免模板走完整 fallback 导致复读原动态刷屏。
-			card.compactMiss = true
-			log.WithField("group_code", notify.GroupCode).
-				WithField("compact_key", notify.compactKey).
-				Warnf("compact notify miss: reply msg not found, suppress origin content (err: %v)", err)
+			card.compactMiss = msg == nil
+			card.resetMessageCache()
+			notify.compactReady = true
+			if msg == nil {
+				log.WithField("group_code", notify.GroupCode).
+					WithField("compact_key", notify.compactKey).
+					Warnf("compact notify miss: reply msg not found, suppress origin content (err: %v)", err)
+			}
 		}
 		log.WithField("compact_key", notify.compactKey).Debug("compact notify")
 	}
@@ -461,6 +463,11 @@ func NewCacheCard(card *Card) *CacheCard {
 	cacheCard := new(CacheCard)
 	cacheCard.Card = card
 	return cacheCard
+}
+
+func (c *CacheCard) resetMessageCache() {
+	c.once = sync.Once{}
+	c.msgCache = nil
 }
 
 type DynamicInfo struct {
@@ -1218,8 +1225,8 @@ func (c *CacheCard) GetMSG() *mmsg.MSG {
 			"msg":          c.orgMsg,
 			"compact_miss": c.compactMiss,
 			"group_code":   c.GroupCode,
-			"parse_post":  config.GlobalConfig.GetBool("bilibili.autoParsePosts"),
-			"dynamic_raw": c.dynamicRaw,
+			"parse_post":   config.GlobalConfig.GetBool("bilibili.autoParsePosts"),
+			"dynamic_raw":  c.dynamicRaw,
 		}
 		var err error
 		c.msgCache, err = template.LoadAndExec("notify.group.bilibili.news.tmpl", data)

--- a/lsp/bilibili/model.go
+++ b/lsp/bilibili/model.go
@@ -296,9 +296,16 @@ func (notify *ConcernNewsNotify) ToMessage() (m *mmsg.MSG) {
 	if notify.shouldCompact {
 		// 通过回复之前消息的方式简化推送
 		m = mmsg.NewMSG()
-		msg, _ := notify.concern.GetNotifyMsg(notify.GroupCode, notify.compactKey)
+		msg, err := notify.concern.GetNotifyMsg(notify.GroupCode, notify.compactKey)
 		if msg != nil {
 			card.orgMsg = msg
+		} else {
+			// 取不到原消息（消息未成功入库、缓存过期或数据库错误），
+			// 标记 compactMiss，避免模板走完整 fallback 导致复读原动态刷屏。
+			card.compactMiss = true
+			log.WithField("group_code", notify.GroupCode).
+				WithField("compact_key", notify.compactKey).
+				Warnf("compact notify miss: reply msg not found, suppress origin content (err: %v)", err)
 		}
 		log.WithField("compact_key", notify.compactKey).Debug("compact notify")
 	}
@@ -444,6 +451,10 @@ type CacheCard struct {
 	dynamic    DynamicInfo
 	dynamicRaw map[string]interface{}
 	orgMsg     *adapter.GroupMessage
+	// compactMiss 表示本条动态需要紧凑推送（shouldCompact），
+	// 但没能从数据库取到可回复的原消息。
+	// 用于让模板区分「首次推送」与「应压缩却查不到原消息」两种 orgMsg == nil 的情况。
+	compactMiss bool
 }
 
 func NewCacheCard(card *Card) *CacheCard {
@@ -1203,9 +1214,10 @@ func (c *CacheCard) GetMSG() *mmsg.MSG {
 	c.once.Do(func() {
 		c.prepare()
 		var data = map[string]interface{}{
-			"dynamic":     c.dynamic,
-			"msg":         c.orgMsg,
-			"group_code":  c.GroupCode,
+			"dynamic":      c.dynamic,
+			"msg":          c.orgMsg,
+			"compact_miss": c.compactMiss,
+			"group_code":   c.GroupCode,
 			"parse_post":  config.GlobalConfig.GetBool("bilibili.autoParsePosts"),
 			"dynamic_raw": c.dynamicRaw,
 		}

--- a/lsp/template/default/notify.group.bilibili.news.tmpl
+++ b/lsp/template/default/notify.group.bilibili.news.tmpl
@@ -4,6 +4,14 @@
 {{ $title := "" -}}
 {{ $orgTopic := "" -}}
 {{ $orgTitle := "" -}}
+{{ $videoAction := .dynamic.Video.Action -}}
+{{ $videoTip := "的视频" -}}
+{{ if eq $videoAction "发布了动态" -}}
+    {{ $videoAction = "发布了动态视频" -}}
+    {{ $videoTip = "的动态视频" -}}
+{{ else if eq $videoAction "" -}}
+    {{ $videoAction = "投稿了视频" -}}
+{{ end -}}
 {{ if ne .dynamic.TopicName "" -}}
     {{ $topic = join "" (list .dynamic.TopicName "\n") -}}
 {{ end -}}
@@ -18,22 +26,22 @@
 {{ end -}}
 {{ if .msg -}}
     {{ reply .msg -}}
-    {{ $tips := "的动态：" -}}
-    {{ if eq .dynamic.Type 8 -}}
-        {{ $tips = "的视频：" -}}
-    {{ else if eq .dynamic.Type 64 -}}
-        {{ $tips = "的专栏：" -}}
+    {{ if and (eq .dynamic.Type 8) (not .dynamic.WithOrigin) -}}
+        {{ $msg = join "" (list .dynamic.User.Name $videoAction "：") -}}
+    {{ else -}}
+        {{ $tips := "的动态：" -}}
+        {{ if eq .dynamic.Type 8 -}}
+            {{ $tips = join "" (list $videoTip "：") -}}
+        {{ else if eq .dynamic.Type 64 -}}
+            {{ $tips = "的专栏：" -}}
+        {{ end -}}
+        {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name $tips) -}}
     {{ end -}}
-    {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name $tips) -}}
     {{ printf "%v\n%v\n%v%v%v\n" $msg .dynamic.Date $topic $title .dynamic.Content -}}
 {{ else if .compact_miss -}}
     {{- /* 应压缩推送但取不到原消息：只发简要提示，避免复读原动态刷屏 */ -}}
     {{ if and (eq .dynamic.Type 8) (not .dynamic.WithOrigin) -}}
-        {{ if ne .dynamic.Video.Action "" -}}
-            {{ $msg = join "" (list .dynamic.User.Name .dynamic.Video.Action "：") -}}
-        {{ else -}}
-            {{ $msg = join "" (list .dynamic.User.Name "投稿了视频：") -}}
-        {{ end -}}
+        {{ $msg = join "" (list .dynamic.User.Name $videoAction "：") -}}
     {{ else -}}
         {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name "的动态：") -}}
     {{ end -}}
@@ -82,19 +90,13 @@
     {{ end -}}
     {{ printf "%v%v\n" $orgTip .dynamic.Text.Content -}}
 {{ else if eq .dynamic.Type 8 -}}
-    {{ $DyVideo := "的视频" -}}
-    {{ if eq .dynamic.Video.Action "发布了动态" -}}
-        {{ $DyVideo = "的动态视频" -}}
-    {{ end -}}
     {{ if .dynamic.WithOrigin -}}
-        {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name $DyVideo "：") -}}
+        {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name $videoTip "：") -}}
         {{ $orgTip = join "" (list "\n\n原视频：" $orgTopic $orgTitle) -}}
-    {{ else if eq $DyVideo "的动态视频" -}}
-        {{ $msg = join "" (list .dynamic.User.Name "发布了动态视频" "：") -}}
     {{ else -}}
-        {{ $msg = join "" (list .dynamic.User.Name .dynamic.Video.Action "：") -}}
+        {{ $msg = join "" (list .dynamic.User.Name $videoAction "：") -}}
     {{ end -}}
-    {{ if eq $DyVideo "的动态视频" -}}
+    {{ if eq $videoTip "的动态视频" -}}
         {{ printf "%v\n%v\n" $msg .dynamic.Date -}}
         {{ printf "%v%v%v" $topic $title .dynamic.Content -}}
         {{- /* 主动态 desc 中的 VIEW_PICTURE 图片 */ -}}

--- a/lsp/template/default/notify.group.bilibili.news.tmpl
+++ b/lsp/template/default/notify.group.bilibili.news.tmpl
@@ -26,6 +26,10 @@
     {{ end -}}
     {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name $tips) -}}
     {{ printf "%v\n%v\n%v%v%v\n" $msg .dynamic.Date $topic $title .dynamic.Content -}}
+{{ else if .compact_miss -}}
+    {{- /* 应压缩推送但取不到原消息：只发简要提示，避免复读原动态刷屏 */ -}}
+    {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name "的动态：") -}}
+    {{ printf "%v\n%v\n" $msg .dynamic.Date -}}
 {{ else if eq .dynamic.Type 2 -}}
     {{ if .dynamic.WithOrigin -}}
         {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name "的动态：") -}}

--- a/lsp/template/default/notify.group.bilibili.news.tmpl
+++ b/lsp/template/default/notify.group.bilibili.news.tmpl
@@ -28,7 +28,15 @@
     {{ printf "%v\n%v\n%v%v%v\n" $msg .dynamic.Date $topic $title .dynamic.Content -}}
 {{ else if .compact_miss -}}
     {{- /* 应压缩推送但取不到原消息：只发简要提示，避免复读原动态刷屏 */ -}}
-    {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name "的动态：") -}}
+    {{ if and (eq .dynamic.Type 8) (not .dynamic.WithOrigin) -}}
+        {{ if ne .dynamic.Video.Action "" -}}
+            {{ $msg = join "" (list .dynamic.User.Name .dynamic.Video.Action "：") -}}
+        {{ else -}}
+            {{ $msg = join "" (list .dynamic.User.Name "投稿了视频：") -}}
+        {{ end -}}
+    {{ else -}}
+        {{ $msg = join "" (list .dynamic.User.Name "转发了" .dynamic.OriginUser.Name "的动态：") -}}
+    {{ end -}}
     {{ printf "%v\n%v\n" $msg .dynamic.Date -}}
 {{ else if eq .dynamic.Type 2 -}}
     {{ if .dynamic.WithOrigin -}}
@@ -318,7 +326,7 @@
         {{ printf "%v\n%v\n" $msg .dynamic.Date -}}
     {{ end -}}
 {{ end -}}
-{{ if gt (len .dynamic.Addons) 0 -}}
+{{ if and (not .compact_miss) (gt (len .dynamic.Addons) 0) -}}
     {{ range $v := .dynamic.Addons -}}
         {{ if eq $v.Type 1 -}}
             {{ printf "\n%v：\n%v\n" $v.Goods.adMark $v.Goods.Name -}}
@@ -349,7 +357,7 @@
 {{ if eq $r.Title "" -}}
     {{ $r = .dynamic.Detail.Reserve -}}
 {{ end -}}
-{{ if ne $r.Title "" -}}
+{{ if and (not .compact_miss) (ne $r.Title "") -}}
     {{ printf "\n%v\n" $r.Title -}}
     {{ if and (ne $r.Desc1 "") (ne $r.Desc2 "") -}}
         {{ printf "%v - %v\n" $r.Desc1 $r.Desc2 -}}
@@ -367,7 +375,7 @@
 {{ if eq $vote nil -}}
     {{ $vote = .dynamic.Detail.Vote -}}
 {{ end -}}
-{{ if $vote -}}
+{{ if and (not .compact_miss) $vote -}}
     {{ printf "\n%v\n" $vote.Title -}}
     {{ if $vote.Desc -}}
         {{ printf "%v\n" $vote.Desc -}}


### PR DESCRIPTION
## 修改内容

- compact miss 时只发送简要提示，避免取不到原消息后复读完整动态
- 修复 FilterHook 提前缓存完整消息后 compact 状态无法重新渲染的问题
- 区分联合投稿视频与转发动态的提示文案
- compact miss 时抑制附加卡片、预约和投票，同时保留动态链接
- 增加真实调用顺序及模板输出回归测试

## 测试

- go test ./lsp/bilibili/...

分支重新基于当前 upstream/next-dev 构建，替代 #35 中的 Bilibili 压缩推送部分。