### PR TITLE
🚨feat(bilibili):账号未登录时私聊预警Bot管理员

### DIFF
--- a/lsp/bilibili/bilibili.go
+++ b/lsp/bilibili/bilibili.go
@@ -275,12 +275,12 @@ func FreshSelfInfo() {
 	} else {
 		if navResp.GetCode() != 0 {
 			if isBilibiliLoginInvalidResponse(navResp.GetCode(), navResp.GetMessage()) {
-				notifyBilibiliLoginExpired()
+				notifyBilibiliLoginExpired(bilibiliLoginSourceSelf)
 			}
 			logger.Errorf("获取个人信息失败 - %v %v", navResp.GetCode(), navResp.GetMessage())
 		} else {
 			if navResp.GetData().GetIsLogin() {
-				resetBilibiliLoginAlert()
+				markBilibiliLoginRecovered(bilibiliLoginSourceSelf)
 				logger.Infof("B站启动成功，当前使用账号：UID:%v %v LV%v %v",
 					navResp.GetData().GetMid(),
 					navResp.GetData().GetVipLabel().GetText(),
@@ -293,7 +293,7 @@ func FreshSelfInfo() {
 				accountUid.Store(navResp.GetData().GetMid())
 				return
 			} else {
-				notifyBilibiliLoginExpired()
+				notifyBilibiliLoginExpired(bilibiliLoginSourceSelf)
 				logger.Errorf("账号未登陆")
 			}
 		}

--- a/lsp/bilibili/bilibili.go
+++ b/lsp/bilibili/bilibili.go
@@ -274,9 +274,13 @@ func FreshSelfInfo() {
 		logger.Errorf("获取个人信息失败 - %v，b站功能可能无法使用", err)
 	} else {
 		if navResp.GetCode() != 0 {
+			if isBilibiliLoginInvalidResponse(navResp.GetCode(), navResp.GetMessage()) {
+				notifyBilibiliLoginExpired()
+			}
 			logger.Errorf("获取个人信息失败 - %v %v", navResp.GetCode(), navResp.GetMessage())
 		} else {
 			if navResp.GetData().GetIsLogin() {
+				resetBilibiliLoginAlert()
 				logger.Infof("B站启动成功，当前使用账号：UID:%v %v LV%v %v",
 					navResp.GetData().GetMid(),
 					navResp.GetData().GetVipLabel().GetText(),
@@ -289,6 +293,7 @@ func FreshSelfInfo() {
 				accountUid.Store(navResp.GetData().GetMid())
 				return
 			} else {
+				notifyBilibiliLoginExpired()
 				logger.Errorf("账号未登陆")
 			}
 		}

--- a/lsp/bilibili/concern_fresher.go
+++ b/lsp/bilibili/concern_fresher.go
@@ -2,6 +2,7 @@ package bilibili
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/Sora233/MiraiGo-Template/config"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/cfg"
@@ -13,7 +14,6 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -274,11 +274,17 @@ func (c *Concern) freshDynamicNew() ([]*NewsInfo, error) {
 	var start = time.Now()
 	resp, err := DynamicSvrDynamicNew()
 	if err != nil {
+		if errors.Is(err, ErrVerifyRequired) {
+			notifyBilibiliLoginExpired()
+		}
 		logger.Errorf("DynamicSvrDynamicNew error %v", err)
 		return nil, err
 	}
 	var newsMap = make(map[int64][]*Card)
 	if resp.GetCode() != 0 {
+		if isBilibiliLoginInvalidResponse(resp.GetCode(), resp.GetMessage()) {
+			notifyBilibiliLoginExpired()
+		}
 		logger.WithField("RespCode", resp.GetCode()).
 			WithField("RespMsg", resp.GetMessage()).
 			Errorf("DynamicSvrDynamicNew failed")
@@ -296,11 +302,17 @@ func (c *Concern) freshDynamicNew() ([]*NewsInfo, error) {
 			}
 			historyResp, err = DynamicSvrDynamicHistory(lastDynamicId)
 			if err != nil {
+				if errors.Is(err, ErrVerifyRequired) {
+					notifyBilibiliLoginExpired()
+				}
 				logger.WithField("lastDynamicId", lastDynamicId).
 					Errorf("DynamicSvrDynamicHistory error %v", err)
 				break
 			}
 			if historyResp.GetCode() != 0 {
+				if isBilibiliLoginInvalidResponse(historyResp.GetCode(), historyResp.GetMessage()) {
+					notifyBilibiliLoginExpired()
+				}
 				logger.WithField("RespCode", resp.GetCode()).
 					WithField("RespMsg", resp.GetMessage()).
 					Errorf("DynamicSvrDynamicHistory failed")
@@ -366,10 +378,14 @@ func (c *Concern) freshLive() ([]*LiveInfo, error) {
 	for {
 		resp, err := FeedList(FeedPageOpt(page))
 		if err != nil {
+			if errors.Is(err, ErrVerifyRequired) {
+				notifyBilibiliLoginExpired()
+			}
 			logger.Errorf("freshLive FeedList error %v", err)
 			return nil, err
 		} else if resp.GetCode() != 0 {
-			if resp.GetCode() == -101 && strings.Contains(resp.GetMessage(), "未登录") {
+			if isBilibiliLoginInvalidResponse(resp.GetCode(), resp.GetMessage()) {
+				notifyBilibiliLoginExpired()
 				logger.Errorf("刷新直播列表失败，可能是cookie失效，将尝试重新获取cookie")
 				ClearCookieInfo(username)
 				atomicVerifyInfo.Store(new(VerifyInfo))

--- a/lsp/bilibili/concern_fresher.go
+++ b/lsp/bilibili/concern_fresher.go
@@ -275,7 +275,7 @@ func (c *Concern) freshDynamicNew() ([]*NewsInfo, error) {
 	resp, err := DynamicSvrDynamicNew()
 	if err != nil {
 		if errors.Is(err, ErrVerifyRequired) {
-			notifyBilibiliLoginExpired()
+			notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
 		}
 		logger.Errorf("DynamicSvrDynamicNew error %v", err)
 		return nil, err
@@ -283,13 +283,14 @@ func (c *Concern) freshDynamicNew() ([]*NewsInfo, error) {
 	var newsMap = make(map[int64][]*Card)
 	if resp.GetCode() != 0 {
 		if isBilibiliLoginInvalidResponse(resp.GetCode(), resp.GetMessage()) {
-			notifyBilibiliLoginExpired()
+			notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
 		}
 		logger.WithField("RespCode", resp.GetCode()).
 			WithField("RespMsg", resp.GetMessage()).
 			Errorf("DynamicSvrDynamicNew failed")
 		return nil, fmt.Errorf("DynamicSvrDynamicNew failed %v - %v", resp.GetCode(), resp.GetMessage())
 	}
+	dynamicLoginHealthy := true
 	var cards []*Card
 	cards = append(cards, resp.GetData().GetCards()...)
 	// 尝试刷一下历史动态，看看能不能捞一下被审核的动态
@@ -303,7 +304,8 @@ func (c *Concern) freshDynamicNew() ([]*NewsInfo, error) {
 			historyResp, err = DynamicSvrDynamicHistory(lastDynamicId)
 			if err != nil {
 				if errors.Is(err, ErrVerifyRequired) {
-					notifyBilibiliLoginExpired()
+					notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+					dynamicLoginHealthy = false
 				}
 				logger.WithField("lastDynamicId", lastDynamicId).
 					Errorf("DynamicSvrDynamicHistory error %v", err)
@@ -311,7 +313,7 @@ func (c *Concern) freshDynamicNew() ([]*NewsInfo, error) {
 			}
 			if historyResp.GetCode() != 0 {
 				if isBilibiliLoginInvalidResponse(historyResp.GetCode(), historyResp.GetMessage()) {
-					notifyBilibiliLoginExpired()
+					notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
 				}
 				logger.WithField("RespCode", resp.GetCode()).
 					WithField("RespMsg", resp.GetMessage()).
@@ -361,6 +363,9 @@ func (c *Concern) freshDynamicNew() ([]*NewsInfo, error) {
 		_ = c.MarkLatestActive(news.Mid, news.Timestamp)
 		_ = c.AddUserInfo(&news.UserInfo)
 	}
+	if dynamicLoginHealthy {
+		markBilibiliLoginRecovered(bilibiliLoginSourceDynamic)
+	}
 	logger.WithField("cost", time.Now().Sub(start)).
 		WithField("NewsInfo Size", len(result)).
 		Trace("freshDynamicNew done")
@@ -379,13 +384,13 @@ func (c *Concern) freshLive() ([]*LiveInfo, error) {
 		resp, err := FeedList(FeedPageOpt(page))
 		if err != nil {
 			if errors.Is(err, ErrVerifyRequired) {
-				notifyBilibiliLoginExpired()
+				notifyBilibiliLoginExpired(bilibiliLoginSourceLive)
 			}
 			logger.Errorf("freshLive FeedList error %v", err)
 			return nil, err
 		} else if resp.GetCode() != 0 {
 			if isBilibiliLoginInvalidResponse(resp.GetCode(), resp.GetMessage()) {
-				notifyBilibiliLoginExpired()
+				notifyBilibiliLoginExpired(bilibiliLoginSourceLive)
 				logger.Errorf("刷新直播列表失败，可能是cookie失效，将尝试重新获取cookie")
 				ClearCookieInfo(username)
 				atomicVerifyInfo.Store(new(VerifyInfo))
@@ -484,6 +489,7 @@ func (c *Concern) freshLive() ([]*LiveInfo, error) {
 	for _, info := range liveInfo {
 		_ = c.MarkLatestActive(info.Mid, ts)
 	}
+	markBilibiliLoginRecovered(bilibiliLoginSourceLive)
 	logger.WithFields(logrus.Fields{
 		"cost":          time.Since(start),
 		"Page":          page,

--- a/lsp/bilibili/login_alert.go
+++ b/lsp/bilibili/login_alert.go
@@ -2,6 +2,7 @@ package bilibili
 
 import (
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/Sora233/MiraiGo-Template/bot"
@@ -10,9 +11,100 @@ import (
 	"github.com/cnxysoft/DDBOT-WSa/utils/msgstringer"
 )
 
+type bilibiliLoginAlertSource uint8
+
+const (
+	bilibiliLoginSourceSelf bilibiliLoginAlertSource = iota
+	bilibiliLoginSourceDynamic
+	bilibiliLoginSourceLive
+)
+
+type bilibiliLoginAlertStatus struct {
+	mu             sync.Mutex
+	generation     uint64
+	invalidSources map[bilibiliLoginAlertSource]struct{}
+	sentAdmins     map[int64]struct{}
+}
+
+func newBilibiliLoginAlertStatus() *bilibiliLoginAlertStatus {
+	return &bilibiliLoginAlertStatus{
+		invalidSources: make(map[bilibiliLoginAlertSource]struct{}),
+		sentAdmins:     make(map[int64]struct{}),
+	}
+}
+
+func (s *bilibiliLoginAlertStatus) markInvalid(source bilibiliLoginAlertSource) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if source == bilibiliLoginSourceSelf {
+		s.invalidSources[bilibiliLoginSourceDynamic] = struct{}{}
+		s.invalidSources[bilibiliLoginSourceLive] = struct{}{}
+	} else {
+		s.invalidSources[source] = struct{}{}
+	}
+	return s.generation
+}
+
+func (s *bilibiliLoginAlertStatus) shouldSend(generation uint64, qq int64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if generation != s.generation {
+		return false
+	}
+	_, sent := s.sentAdmins[qq]
+	return !sent
+}
+
+func (s *bilibiliLoginAlertStatus) markSent(generation uint64, qq int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if generation == s.generation {
+		s.sentAdmins[qq] = struct{}{}
+	}
+}
+
+func (s *bilibiliLoginAlertStatus) markRecovered(source bilibiliLoginAlertSource) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if source == bilibiliLoginSourceSelf {
+		if len(s.invalidSources) == 0 {
+			return false
+		}
+		s.invalidSources = make(map[bilibiliLoginAlertSource]struct{})
+	} else {
+		if _, invalid := s.invalidSources[source]; !invalid {
+			return false
+		}
+		delete(s.invalidSources, source)
+		if len(s.invalidSources) != 0 {
+			return false
+		}
+	}
+	s.generation++
+	s.sentAdmins = make(map[int64]struct{})
+	return true
+}
+
+func (s *bilibiliLoginAlertStatus) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.generation++
+	s.invalidSources = make(map[bilibiliLoginAlertSource]struct{})
+	s.sentAdmins = make(map[int64]struct{})
+}
+
 var (
-	bilibiliLoginAlertSent atomic.Bool
-	sendBilibiliLoginAlert = sendBilibiliLoginExpiredAlertToAdmins
+	bilibiliLoginAlertState   = newBilibiliLoginAlertStatus()
+	bilibiliLoginAlertSending atomic.Bool
+
+	listBilibiliLoginAlertAdmins = func() []int64 {
+		return permission.NewStateManager().ListAdmin()
+	}
+	bilibiliLoginAlertBotReady = func() bool {
+		return bot.Instance != nil && bot.Instance.Messenger != nil && bot.Instance.Adapter != nil &&
+			bot.Instance.Messenger.Online.Load() && bot.Instance.Adapter.IsConnected()
+	}
+	sendBilibiliLoginAlertToAdmin = sendBilibiliLoginExpiredAlertToAdmin
 )
 
 func isBilibiliLoginInvalidResponse(code int32, message string) bool {
@@ -20,44 +112,50 @@ func isBilibiliLoginInvalidResponse(code int32, message string) bool {
 		strings.Contains(message, "未登录")
 }
 
-func notifyBilibiliLoginExpired() {
-	if !bilibiliLoginAlertSent.CompareAndSwap(false, true) {
+func notifyBilibiliLoginExpired(source bilibiliLoginAlertSource) {
+	generation := bilibiliLoginAlertState.markInvalid(source)
+	if !bilibiliLoginAlertSending.CompareAndSwap(false, true) {
 		return
 	}
-	if !sendBilibiliLoginAlert() {
-		bilibiliLoginAlertSent.Store(false)
-	}
-}
+	defer bilibiliLoginAlertSending.Store(false)
 
-func resetBilibiliLoginAlert() {
-	bilibiliLoginAlertSent.Store(false)
-}
-
-func sendBilibiliLoginExpiredAlertToAdmins() bool {
-	if bot.Instance == nil || !bot.Instance.Online.Load() {
-		logger.Warn("Bot未在线，无法发送B站登录失效预警")
-		return false
-	}
-
-	admins := permission.NewStateManager().ListAdmin()
+	admins := listBilibiliLoginAlertAdmins()
 	if len(admins) == 0 {
 		logger.Warn("未配置Bot管理员，无法发送B站登录失效预警")
-		return false
+		return
+	}
+	if !bilibiliLoginAlertBotReady() {
+		logger.Warn("Bot未在线，无法发送B站登录失效预警")
+		return
 	}
 
-	sent := false
 	for _, qq := range admins {
-		msg := newBilibiliLoginExpiredAlertMessage().ToCombineMessage(mmsg.NewPrivateTarget(qq))
-		summary := msgstringer.AdapterMsgToString(msg.Elements)
-		result := bot.Instance.SendPrivateMessage(qq, msg, summary)
-		if result == nil || result.ID == -1 {
-			logger.WithField("QQ", qq).Error("发送B站登录失效预警失败")
+		if !bilibiliLoginAlertState.shouldSend(generation, qq) {
 			continue
 		}
-		sent = true
-		logger.WithField("QQ", qq).Info("已发送B站登录失效预警")
+		if !sendBilibiliLoginAlertToAdmin(qq) {
+			continue
+		}
+		bilibiliLoginAlertState.markSent(generation, qq)
 	}
-	return sent
+}
+
+func markBilibiliLoginRecovered(source bilibiliLoginAlertSource) {
+	if bilibiliLoginAlertState.markRecovered(source) {
+		logger.Info("B站登录接口已恢复，重置登录失效预警状态")
+	}
+}
+
+func sendBilibiliLoginExpiredAlertToAdmin(qq int64) bool {
+	msg := newBilibiliLoginExpiredAlertMessage().ToCombineMessage(mmsg.NewPrivateTarget(qq))
+	summary := msgstringer.AdapterMsgToString(msg.Elements)
+	result := bot.Instance.SendPrivateMessage(qq, msg, summary)
+	if result == nil || result.ID == -1 {
+		logger.WithField("QQ", qq).Error("发送B站登录失效预警失败")
+		return false
+	}
+	logger.WithField("QQ", qq).Info("已发送B站登录失效预警")
+	return true
 }
 
 func newBilibiliLoginExpiredAlertMessage() *mmsg.MSG {

--- a/lsp/bilibili/login_alert.go
+++ b/lsp/bilibili/login_alert.go
@@ -1,0 +1,68 @@
+package bilibili
+
+import (
+	"strings"
+	"sync/atomic"
+
+	"github.com/Sora233/MiraiGo-Template/bot"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/mmsg"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/permission"
+	"github.com/cnxysoft/DDBOT-WSa/utils/msgstringer"
+)
+
+var (
+	bilibiliLoginAlertSent atomic.Bool
+	sendBilibiliLoginAlert = sendBilibiliLoginExpiredAlertToAdmins
+)
+
+func isBilibiliLoginInvalidResponse(code int32, message string) bool {
+	return (code == -101 || code == 4100000) &&
+		strings.Contains(message, "未登录")
+}
+
+func notifyBilibiliLoginExpired() {
+	if !bilibiliLoginAlertSent.CompareAndSwap(false, true) {
+		return
+	}
+	if !sendBilibiliLoginAlert() {
+		bilibiliLoginAlertSent.Store(false)
+	}
+}
+
+func resetBilibiliLoginAlert() {
+	bilibiliLoginAlertSent.Store(false)
+}
+
+func sendBilibiliLoginExpiredAlertToAdmins() bool {
+	if bot.Instance == nil || !bot.Instance.Online.Load() {
+		logger.Warn("Bot未在线，无法发送B站登录失效预警")
+		return false
+	}
+
+	admins := permission.NewStateManager().ListAdmin()
+	if len(admins) == 0 {
+		logger.Warn("未配置Bot管理员，无法发送B站登录失效预警")
+		return false
+	}
+
+	sent := false
+	for _, qq := range admins {
+		msg := newBilibiliLoginExpiredAlertMessage().ToCombineMessage(mmsg.NewPrivateTarget(qq))
+		summary := msgstringer.AdapterMsgToString(msg.Elements)
+		result := bot.Instance.SendPrivateMessage(qq, msg, summary)
+		if result == nil || result.ID == -1 {
+			logger.WithField("QQ", qq).Error("发送B站登录失效预警失败")
+			continue
+		}
+		sent = true
+		logger.WithField("QQ", qq).Info("已发送B站登录失效预警")
+	}
+	return sent
+}
+
+func newBilibiliLoginExpiredAlertMessage() *mmsg.MSG {
+	return mmsg.NewText("[B站登录失效预警]\n" +
+		"检测到B站账号未登录，动态和直播订阅推送已停止。\n" +
+		"请更新application.yaml中的bilibili.SESSDATA和bilibili.bili_jct后重启；" +
+		"或开启bilibili.QRLogin、清空这两项并重启，通过二维码重新登录。")
+}

--- a/lsp/bilibili/login_alert_test.go
+++ b/lsp/bilibili/login_alert_test.go
@@ -1,0 +1,101 @@
+package bilibili
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cnxysoft/DDBOT-WSa/lsp/mmsg"
+	"github.com/cnxysoft/DDBOT-WSa/utils/msgstringer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsBilibiliLoginInvalidResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    int32
+		message string
+		want    bool
+	}{
+		{name: "直播账号未登录", code: -101, message: "账号未登录", want: true},
+		{name: "动态用户未登录", code: 4100000, message: "用户未登录", want: true},
+		{name: "其他接口错误", code: -400, message: "请求错误", want: false},
+		{name: "相同错误码但不是登录错误", code: -101, message: "账号异常", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isBilibiliLoginInvalidResponse(tt.code, tt.message))
+		})
+	}
+}
+
+func TestNotifyBilibiliLoginExpiredOnlyOnceAfterSuccess(t *testing.T) {
+	setBilibiliLoginAlertSenderForTest(t, func() bool { return true })
+
+	notifyBilibiliLoginExpired()
+	notifyBilibiliLoginExpired()
+
+	assert.True(t, bilibiliLoginAlertSent.Load())
+	assert.Equal(t, 1, bilibiliLoginAlertSendCount)
+}
+
+func TestNotifyBilibiliLoginExpiredOnlyOnceWhenConcurrent(t *testing.T) {
+	var calls atomic.Int32
+	setBilibiliLoginAlertSenderForTest(t, func() bool {
+		calls.Add(1)
+		return true
+	})
+
+	var waitGroup sync.WaitGroup
+	for range 20 {
+		waitGroup.Go(notifyBilibiliLoginExpired)
+	}
+	waitGroup.Wait()
+
+	assert.EqualValues(t, 1, calls.Load())
+}
+
+func TestNotifyBilibiliLoginExpiredRetriesAfterFailure(t *testing.T) {
+	attempt := 0
+	setBilibiliLoginAlertSenderForTest(t, func() bool {
+		attempt++
+		return attempt > 1
+	})
+
+	notifyBilibiliLoginExpired()
+	assert.False(t, bilibiliLoginAlertSent.Load())
+	notifyBilibiliLoginExpired()
+	notifyBilibiliLoginExpired()
+
+	assert.True(t, bilibiliLoginAlertSent.Load())
+	assert.Equal(t, 2, bilibiliLoginAlertSendCount)
+}
+
+func TestBilibiliLoginExpiredAlertMessage(t *testing.T) {
+	msg := newBilibiliLoginExpiredAlertMessage().ToCombineMessage(mmsg.NewPrivateTarget(1))
+	text := msgstringer.AdapterMsgToString(msg.Elements)
+
+	assert.Contains(t, text, "动态和直播订阅推送已停止")
+	assert.Contains(t, text, "bilibili.SESSDATA")
+	assert.Contains(t, text, "bilibili.bili_jct")
+	assert.Contains(t, text, "bilibili.QRLogin")
+}
+
+var bilibiliLoginAlertSendCount int
+
+func setBilibiliLoginAlertSenderForTest(t *testing.T, sender func() bool) {
+	t.Helper()
+	originalSender := sendBilibiliLoginAlert
+	bilibiliLoginAlertSendCount = 0
+	bilibiliLoginAlertSent.Store(false)
+	sendBilibiliLoginAlert = func() bool {
+		bilibiliLoginAlertSendCount++
+		return sender()
+	}
+	t.Cleanup(func() {
+		sendBilibiliLoginAlert = originalSender
+		bilibiliLoginAlertSent.Store(false)
+		bilibiliLoginAlertSendCount = 0
+	})
+}

--- a/lsp/bilibili/login_alert_test.go
+++ b/lsp/bilibili/login_alert_test.go
@@ -31,45 +31,142 @@ func TestIsBilibiliLoginInvalidResponse(t *testing.T) {
 }
 
 func TestNotifyBilibiliLoginExpiredOnlyOnceAfterSuccess(t *testing.T) {
-	setBilibiliLoginAlertSenderForTest(t, func() bool { return true })
+	var calls int
+	setBilibiliLoginAlertDependenciesForTest(t, []int64{1}, func(int64) bool {
+		calls++
+		return true
+	})
 
-	notifyBilibiliLoginExpired()
-	notifyBilibiliLoginExpired()
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
 
-	assert.True(t, bilibiliLoginAlertSent.Load())
-	assert.Equal(t, 1, bilibiliLoginAlertSendCount)
+	assert.Equal(t, 1, calls)
 }
 
 func TestNotifyBilibiliLoginExpiredOnlyOnceWhenConcurrent(t *testing.T) {
 	var calls atomic.Int32
-	setBilibiliLoginAlertSenderForTest(t, func() bool {
+	setBilibiliLoginAlertDependenciesForTest(t, []int64{1}, func(int64) bool {
 		calls.Add(1)
 		return true
 	})
 
 	var waitGroup sync.WaitGroup
 	for range 20 {
-		waitGroup.Go(notifyBilibiliLoginExpired)
+		waitGroup.Go(func() {
+			notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+		})
 	}
 	waitGroup.Wait()
 
 	assert.EqualValues(t, 1, calls.Load())
 }
 
-func TestNotifyBilibiliLoginExpiredRetriesAfterFailure(t *testing.T) {
-	attempt := 0
-	setBilibiliLoginAlertSenderForTest(t, func() bool {
-		attempt++
-		return attempt > 1
+func TestNotifyBilibiliLoginExpiredRetriesOnlyFailedAdmins(t *testing.T) {
+	calls := make(map[int64]int)
+	setBilibiliLoginAlertDependenciesForTest(t, []int64{1, 2}, func(qq int64) bool {
+		calls[qq]++
+		return qq == 1 || calls[qq] > 1
 	})
 
-	notifyBilibiliLoginExpired()
-	assert.False(t, bilibiliLoginAlertSent.Load())
-	notifyBilibiliLoginExpired()
-	notifyBilibiliLoginExpired()
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
 
-	assert.True(t, bilibiliLoginAlertSent.Load())
-	assert.Equal(t, 2, bilibiliLoginAlertSendCount)
+	assert.Equal(t, 1, calls[1])
+	assert.Equal(t, 2, calls[2])
+}
+
+func TestNotifyBilibiliLoginExpiredRetriesAfterBotRecovery(t *testing.T) {
+	var calls int
+	ready := false
+	setBilibiliLoginAlertDependenciesForTest(t, []int64{1}, func(int64) bool {
+		calls++
+		return true
+	})
+	bilibiliLoginAlertBotReady = func() bool { return ready }
+
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+	assert.Equal(t, 0, calls)
+
+	ready = true
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+	assert.Equal(t, 1, calls)
+}
+
+func TestBilibiliLoginAlertResetsAfterSameInterfaceRecovery(t *testing.T) {
+	for _, source := range []bilibiliLoginAlertSource{
+		bilibiliLoginSourceDynamic,
+		bilibiliLoginSourceLive,
+	} {
+		t.Run(sourceName(source), func(t *testing.T) {
+			var calls int
+			setBilibiliLoginAlertDependenciesForTest(t, []int64{1}, func(int64) bool {
+				calls++
+				return true
+			})
+
+			notifyBilibiliLoginExpired(source)
+			notifyBilibiliLoginExpired(source)
+			assert.Equal(t, 1, calls)
+
+			markBilibiliLoginRecovered(source)
+			notifyBilibiliLoginExpired(source)
+			assert.Equal(t, 2, calls)
+		})
+	}
+}
+
+func TestBilibiliLoginAlertSelfCheckWaitsForRoutineInterfaces(t *testing.T) {
+	var calls int
+	setBilibiliLoginAlertDependenciesForTest(t, []int64{1}, func(int64) bool {
+		calls++
+		return true
+	})
+
+	notifyBilibiliLoginExpired(bilibiliLoginSourceSelf)
+	markBilibiliLoginRecovered(bilibiliLoginSourceDynamic)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceLive)
+	assert.Equal(t, 1, calls)
+
+	markBilibiliLoginRecovered(bilibiliLoginSourceLive)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+	assert.Equal(t, 2, calls)
+}
+
+func TestBilibiliLoginAlertSelfCheckRecoveryResetsAllInterfaces(t *testing.T) {
+	var calls int
+	setBilibiliLoginAlertDependenciesForTest(t, []int64{1}, func(int64) bool {
+		calls++
+		return true
+	})
+
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceLive)
+	markBilibiliLoginRecovered(bilibiliLoginSourceSelf)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+
+	assert.Equal(t, 2, calls)
+}
+
+func TestBilibiliLoginAlertWaitsForAllFailedInterfacesToRecover(t *testing.T) {
+	var calls int
+	setBilibiliLoginAlertDependenciesForTest(t, []int64{1}, func(int64) bool {
+		calls++
+		return true
+	})
+
+	notifyBilibiliLoginExpired(bilibiliLoginSourceDynamic)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceLive)
+	assert.Equal(t, 1, calls)
+
+	markBilibiliLoginRecovered(bilibiliLoginSourceDynamic)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceLive)
+	assert.Equal(t, 1, calls)
+
+	markBilibiliLoginRecovered(bilibiliLoginSourceLive)
+	notifyBilibiliLoginExpired(bilibiliLoginSourceLive)
+	assert.Equal(t, 2, calls)
 }
 
 func TestBilibiliLoginExpiredAlertMessage(t *testing.T) {
@@ -82,20 +179,36 @@ func TestBilibiliLoginExpiredAlertMessage(t *testing.T) {
 	assert.Contains(t, text, "bilibili.QRLogin")
 }
 
-var bilibiliLoginAlertSendCount int
-
-func setBilibiliLoginAlertSenderForTest(t *testing.T, sender func() bool) {
+func setBilibiliLoginAlertDependenciesForTest(t *testing.T, admins []int64, sender func(int64) bool) {
 	t.Helper()
-	originalSender := sendBilibiliLoginAlert
-	bilibiliLoginAlertSendCount = 0
-	bilibiliLoginAlertSent.Store(false)
-	sendBilibiliLoginAlert = func() bool {
-		bilibiliLoginAlertSendCount++
-		return sender()
+	originalListAdmins := listBilibiliLoginAlertAdmins
+	originalBotReady := bilibiliLoginAlertBotReady
+	originalSender := sendBilibiliLoginAlertToAdmin
+
+	bilibiliLoginAlertState.reset()
+	bilibiliLoginAlertSending.Store(false)
+	listBilibiliLoginAlertAdmins = func() []int64 {
+		return append([]int64(nil), admins...)
 	}
+	bilibiliLoginAlertBotReady = func() bool { return true }
+	sendBilibiliLoginAlertToAdmin = sender
+
 	t.Cleanup(func() {
-		sendBilibiliLoginAlert = originalSender
-		bilibiliLoginAlertSent.Store(false)
-		bilibiliLoginAlertSendCount = 0
+		listBilibiliLoginAlertAdmins = originalListAdmins
+		bilibiliLoginAlertBotReady = originalBotReady
+		sendBilibiliLoginAlertToAdmin = originalSender
+		bilibiliLoginAlertState.reset()
+		bilibiliLoginAlertSending.Store(false)
 	})
+}
+
+func sourceName(source bilibiliLoginAlertSource) string {
+	switch source {
+	case bilibiliLoginSourceDynamic:
+		return "dynamic"
+	case bilibiliLoginSourceLive:
+		return "live"
+	default:
+		return "self"
+	}
 }


### PR DESCRIPTION
## 改动

- 识别动态接口4100000、直播接口-101以及凭证缺失等登录失效路径
- B站账号未登录时，私聊全部Bot全局管理员，说明动态和直播推送已停止并提供Cookie、二维码恢复指引
- 使用原子状态避免动态与直播并发重复告警；发送失败允许后续轮询重试，登录恢复后重置告警状态
- 补充错误码、去重、并发、失败重试和告警文案测试

## 测试

- go test ./lsp/bilibili/...
- go test -race ./lsp/bilibili -run 本次告警相关测试