### PR TITLE
实现推特正文关键词过滤和修复b站模板无法创建调试文件

### DIFF
--- a/lsp/concern/concern.go
+++ b/lsp/concern/concern.go
@@ -26,6 +26,12 @@ type Notify interface {
 	ToMessage() *mmsg.MSG
 }
 
+// TextFilterContentProvider 允许通知直接提供关键词过滤文本，避免为了过滤而提前渲染消息。
+// 未实现该接口的通知仍使用 ToMessage 的文本内容。
+type TextFilterContentProvider interface {
+	TextFilterContent() string
+}
+
 // Concern 是DDBOT的一个完整订阅模块，包含一个订阅源的全部信息
 // 当一个 Concern 编写完成后，需要使用 concern.RegisterConcern 向DDBOT注册才能生效
 type Concern interface {

--- a/lsp/concern/config.go
+++ b/lsp/concern/config.go
@@ -50,7 +50,12 @@ func (g *GroupConcernConfig) FilterHook(notify Notify) *HookResult {
 	}
 	var combinedResult = new(HookResult)
 	combinedResult.Pass = true
-	msgString := msgstringer.AdapterMsgToString(notify.ToMessage().Elements())
+	var msgString string
+	if provider, ok := notify.(TextFilterContentProvider); ok {
+		msgString = provider.TextFilterContent()
+	} else {
+		msgString = msgstringer.AdapterMsgToString(notify.ToMessage().Elements())
+	}
 	logger := notify.Logger().WithField("FilterRules", g.GetGroupConcernFilter().RulesNormalized())
 	for _, rule := range g.GetGroupConcernFilter().RulesNormalized() {
 		switch rule.Type {

--- a/lsp/concern/stateManager.go
+++ b/lsp/concern/stateManager.go
@@ -117,6 +117,12 @@ func (c *StateManager) getGroupConcernConfig(groupCode int64, id interface{}) (c
 	if concernConfig == nil {
 		concernConfig = new(GroupConcernConfig)
 	}
+	if err := concernConfig.GetGroupConcernFilter().ValidateTextConflict(); err != nil {
+		c.Logger().WithFields(localutils.GroupLogFields(groupCode)).
+			WithFields(logrus.Fields{"id": id, "error": err}).
+			Error("历史关键词过滤配置无效，本次加载已禁用全部过滤规则")
+		concernConfig.GetGroupConcernFilter().Clear()
+	}
 	return
 }
 

--- a/lsp/concern/stateManager_test.go
+++ b/lsp/concern/stateManager_test.go
@@ -300,6 +300,52 @@ func TestStateManager_GroupConcernConfig(t *testing.T) {
 	assert.EqualValues(t, ErrConfigNotSupported, err)
 }
 
+func TestStateManagerDisablesInvalidPersistedTextFilter(t *testing.T) {
+	test.InitBuntdb(t)
+	defer test.CloseBuntdb(t)
+
+	sm := newStateManager(t)
+	textRule := func(words ...string) string {
+		return (&GroupConcernFilterConfigByText{Text: words}).ToString()
+	}
+	tests := []struct {
+		name  string
+		id    int64
+		setup func(*GroupConcernFilterConfig)
+	}{
+		{
+			name: "空关键词",
+			id:   91001,
+			setup: func(filter *GroupConcernFilterConfig) {
+				filter.SetRule(FilterTypeText, textRule(""))
+			},
+		},
+		{
+			name: "关键词冲突",
+			id:   91002,
+			setup: func(filter *GroupConcernFilterConfig) {
+				filter.SetRule(FilterTypeText, textRule("原神"))
+				filter.SetRule(FilterTypeNotText, textRule("原神"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := new(GroupConcernConfig)
+			stored.GetGroupConcernNotify().TitleChangeNotify = testType
+			tt.setup(stored.GetGroupConcernFilter())
+			assert.NoError(t, sm.SetJson(sm.GroupConcernConfigKey(test.G1, tt.id), stored))
+
+			loaded := sm.GetGroupConcernConfig(test.G1, tt.id)
+
+			assert.True(t, loaded.GetGroupConcernFilter().Empty())
+			assert.Equal(t, testType, loaded.GetGroupConcernNotify().TitleChangeNotify)
+			assert.NoError(t, loaded.Validate())
+		})
+	}
+}
+
 func TestStateManager_CheckAndSetAtAllMark(t *testing.T) {
 	test.InitBuntdb(t)
 	defer test.CloseBuntdb(t)

--- a/lsp/template/funcs_ext_test.go
+++ b/lsp/template/funcs_ext_test.go
@@ -124,6 +124,13 @@ func TestFileFuncs(t *testing.T) {
 	data = openFile(tempFile)
 	assert.Equal(t, []byte(content+"\nnew line"), data)
 
+	// updateFile 应能创建不存在的调试文件并写入内容。
+	debugFile := filepath.Join(tempDir, "debug.json")
+	err = updateFile(debugFile, "debug data")
+	assert.NoError(t, err)
+	data = openFile(debugFile)
+	assert.Equal(t, []byte("debug data"), data)
+
 	// 测试delFile
 	err = delFile(tempFile)
 	assert.NoError(t, err)

--- a/lsp/template/funcs_fsys_ext.go
+++ b/lsp/template/funcs_fsys_ext.go
@@ -19,7 +19,7 @@ func openFile(path string) []byte {
 }
 
 func updateFile(path string, data string) error {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 	if err != nil {
 		logger.Errorf("template: openFile <%v> error %v", path, err)
 		return err

--- a/lsp/twitter/config.go
+++ b/lsp/twitter/config.go
@@ -12,7 +12,7 @@ type GroupConcernConfig struct {
 	concern *twitterConcern
 }
 
-// FilterHook 保留通用正文过滤，避免Twitter包装层绕过text/not_text规则。
+// FilterHook 保留通用关键词过滤；ConcernNewsNotify会直接提供模板动态文字，避免提前渲染消息。
 func (g *GroupConcernConfig) FilterHook(notify concern.Notify) *concern.HookResult {
 	return g.IConfig.FilterHook(notify)
 }

--- a/lsp/twitter/config.go
+++ b/lsp/twitter/config.go
@@ -6,15 +6,15 @@ import (
 	"github.com/cnxysoft/DDBOT-WSa/lsp/concern"
 )
 
-// GroupConcernConfig 创建一个新结构，准备重写 FilterHook
+// GroupConcernConfig 在通用配置上扩展Twitter推送回调。
 type GroupConcernConfig struct {
 	concern.IConfig
 	concern *twitterConcern
 }
 
-// FilterHook 可以在这里自定义过滤逻辑
-func (g *GroupConcernConfig) FilterHook(concern.Notify) *concern.HookResult {
-	return concern.HookResultPass
+// FilterHook 保留通用正文过滤，避免Twitter包装层绕过text/not_text规则。
+func (g *GroupConcernConfig) FilterHook(notify concern.Notify) *concern.HookResult {
+	return g.IConfig.FilterHook(notify)
 }
 
 // 还有更多方法可以重载

--- a/lsp/twitter/config_test.go
+++ b/lsp/twitter/config_test.go
@@ -2,6 +2,7 @@ package twitter
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cnxysoft/DDBOT-WSa/lsp/concern"
 	"github.com/cnxysoft/DDBOT-WSa/lsp/concern_type"
@@ -79,6 +80,69 @@ func TestGroupConcernConfigFilterHookUsesTextRules(t *testing.T) {
 			result := config.FilterHook(&filterTestNotify{content: tt.content})
 
 			assert.Equal(t, tt.wantPass, result.Pass)
+		})
+	}
+}
+
+func TestGroupConcernConfigFilterHookUsesDynamicTwitterText(t *testing.T) {
+	originalMode := TwitterMode
+	TwitterMode = ModeAPI
+	defer func() { TwitterMode = originalMode }()
+
+	createdAt := time.Date(2026, time.August, 9, 8, 30, 0, 0, time.UTC)
+	newsInfo := &NewsInfo{
+		UserInfo: &UserInfo{Id: "publisher_id", Name: "订阅作者"},
+		Tweet: &Tweet{
+			ID:        "123456",
+			Content:   "正文关键词",
+			CreatedAt: createdAt,
+			IsRetweet: true,
+			Url:       "https://x.com/publisher_id/status/123456",
+			OrgUser: &UserProfile{
+				Name:       "被转发作者",
+				ScreenName: "retweeted_id",
+			},
+			QuoteTweet: &Tweet{
+				Content:   "引用正文",
+				CreatedAt: createdAt.Add(-time.Hour),
+				OrgUser: &UserProfile{
+					Name:       "引用作者",
+					ScreenName: "quoted_id",
+				},
+			},
+		},
+	}
+	notify := NewConcernNewsNotify(1, newsInfo, nil)
+
+	tests := []struct {
+		name     string
+		ruleType string
+		keyword  string
+		wantPass bool
+	}{
+		{name: "正文参与匹配", ruleType: concern.FilterTypeText, keyword: "正文关键词", wantPass: true},
+		{name: "订阅作者参与匹配", ruleType: concern.FilterTypeText, keyword: "订阅作者", wantPass: true},
+		{name: "账号名参与匹配", ruleType: concern.FilterTypeText, keyword: "publisher_id", wantPass: true},
+		{name: "推文URL参与匹配", ruleType: concern.FilterTypeText, keyword: "x.com/publisher_id/status", wantPass: true},
+		{name: "转发作者参与匹配", ruleType: concern.FilterTypeText, keyword: "被转发作者", wantPass: true},
+		{name: "引用正文参与匹配", ruleType: concern.FilterTypeText, keyword: "引用正文", wantPass: true},
+		{name: "引用账号名参与匹配", ruleType: concern.FilterTypeText, keyword: "quoted_id", wantPass: true},
+		{name: "固定模板文字不参与匹配", ruleType: concern.FilterTypeText, keyword: "发布了新推文", wantPass: false},
+		{name: "固定模板文字不触发排除", ruleType: concern.FilterTypeNotText, keyword: "转发了", wantPass: true},
+		{name: "动态作者仍可触发排除", ruleType: concern.FilterTypeNotText, keyword: "被转发作者", wantPass: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseConfig := new(concern.GroupConcernConfig)
+			baseConfig.GetGroupConcernFilter().SetRule(tt.ruleType,
+				(&concern.GroupConcernFilterConfigByText{Text: []string{tt.keyword}}).ToString())
+			config := NewGroupConcernConfig(baseConfig, nil)
+
+			result := config.FilterHook(notify)
+
+			assert.Equal(t, tt.wantPass, result.Pass)
+			assert.Empty(t, newsInfo.dynamic.Content, "过滤阶段不应提前渲染并缓存模板数据")
 		})
 	}
 }

--- a/lsp/twitter/config_test.go
+++ b/lsp/twitter/config_test.go
@@ -1,0 +1,84 @@
+package twitter
+
+import (
+	"testing"
+
+	"github.com/cnxysoft/DDBOT-WSa/lsp/concern"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/concern_type"
+	"github.com/cnxysoft/DDBOT-WSa/lsp/mmsg"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type filterTestNotify struct {
+	content string
+}
+
+func (n *filterTestNotify) Site() string {
+	return Site
+}
+
+func (n *filterTestNotify) Type() concern_type.Type {
+	return Tweets
+}
+
+func (n *filterTestNotify) GetUid() interface{} {
+	return "test"
+}
+
+func (n *filterTestNotify) Logger() *logrus.Entry {
+	return logrus.WithField("Site", Site)
+}
+
+func (n *filterTestNotify) GetGroupCode() int64 {
+	return 1
+}
+
+func (n *filterTestNotify) ToMessage() *mmsg.MSG {
+	return mmsg.NewText(n.content)
+}
+
+func TestGroupConcernConfigFilterHookUsesTextRules(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleType string
+		keyword  string
+		content  string
+		wantPass bool
+	}{
+		{
+			name:     "text未命中时拦截",
+			ruleType: concern.FilterTypeText,
+			keyword:  "壁紙配布",
+			content:  "普通活动公告",
+			wantPass: false,
+		},
+		{
+			name:     "text命中时放行",
+			ruleType: concern.FilterTypeText,
+			keyword:  "壁紙配布",
+			content:  "壁紙配布のお知らせ",
+			wantPass: true,
+		},
+		{
+			name:     "not_text命中时拦截",
+			ruleType: concern.FilterTypeNotText,
+			keyword:  "中奖",
+			content:  "恭喜中奖",
+			wantPass: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseConfig := new(concern.GroupConcernConfig)
+			baseConfig.GetGroupConcernFilter().SetRule(tt.ruleType,
+				(&concern.GroupConcernFilterConfigByText{Text: []string{tt.keyword}}).ToString())
+			config := NewGroupConcernConfig(baseConfig, nil)
+
+			result := config.FilterHook(&filterTestNotify{content: tt.content})
+
+			assert.Equal(t, tt.wantPass, result.Pass)
+		})
+	}
+}

--- a/lsp/twitter/notify.go
+++ b/lsp/twitter/notify.go
@@ -81,6 +81,53 @@ func (n *ConcernNewsNotify) ToMessage() (m *mmsg.MSG) {
 	return n.GetMSG(n)
 }
 
+// TextFilterContent 返回模板中的动态文字，供 text/not_text 规则匹配。
+// 这里不调用 ToMessage，避免在 NotifyBeforeCallback 设置紧凑状态前缓存模板渲染结果。
+func (n *ConcernNewsNotify) TextFilterContent() string {
+	if n == nil || n.NewsInfo == nil {
+		return ""
+	}
+
+	parts := make([]string, 0, 12)
+	appendText := func(values ...string) {
+		for _, value := range values {
+			if value != "" {
+				parts = append(parts, value)
+			}
+		}
+	}
+
+	if n.UserInfo != nil {
+		appendText(n.UserInfo.Name, n.UserInfo.Id)
+	}
+	if n.Tweet == nil {
+		return strings.Join(parts, "\n")
+	}
+
+	tweet := n.Tweet
+	appendText(tweet.Content, tweet.Url)
+	createdAt := tweet.CreatedAt
+	if TwitterMode != ModeAPI && tweet.IsRetweet {
+		createdAt = time.Now().UTC()
+	}
+	if !createdAt.IsZero() {
+		appendText(CSTTime(createdAt).Format(time.DateTime))
+	}
+	if (tweet.IsRetweet || tweet.QuoteTweet != nil) && tweet.OrgUser != nil {
+		appendText(tweet.OrgUser.Name, tweet.OrgUser.ScreenName)
+	}
+	if quote := tweet.QuoteTweet; quote != nil {
+		appendText(quote.Content)
+		if !quote.CreatedAt.IsZero() {
+			appendText(CSTTime(quote.CreatedAt).Format(time.DateTime))
+		}
+		if quote.OrgUser != nil {
+			appendText(quote.OrgUser.Name, quote.OrgUser.ScreenName)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
 // buildTwitterDynamic 构建TwitterDynamic数据
 func (n *ConcernNewsNotify) buildTwitterDynamic() TwitterDynamic {
 	dynamic := TwitterDynamic{}


### PR DESCRIPTION
✨feat(twitter)：恢复正文关键词过滤
    
- Twitter自定义GroupConcernConfig此前直接返回放行，导致所有text和not_text正文
规则被绕过。
- 现在将FilterHook委托给底层通用配置，并增加text命中、text未命中及not_text命中的回归测试。

🐛fix(bili-template)：自动创建调试追加文件

- updateFile追加不存在的目标文件时启用O_CREATE，避免B站推送模板写入debug.json报文件不存在。
- 补充不存在文件时创建并写入的回归测试。