### PR TITLE
fix(twitter): 镜像失败时自动切换重试

### DIFF
--- a/lsp/twitter/concern.go
+++ b/lsp/twitter/concern.go
@@ -49,11 +49,29 @@ const (
 )
 
 var (
-	logger          = templUtils.GetModuleLogger(ConcernName)
-	requestInterval = time.Second * 5 // 每个请求之间的间隔
-	buildProfileURL = func(screenName string) *url.URL {
-		Url, _ := url.Parse(BaseURL[rand.Intn(len(BaseURL))] + screenName)
-		return Url
+	logger           = templUtils.GetModuleLogger(ConcernName)
+	requestInterval  = time.Second * 5 // 每个请求之间的间隔
+	buildProfileURLs = func(screenName string) []*url.URL {
+		if len(BaseURL) == 0 {
+			return nil
+		}
+		start := rand.Intn(len(BaseURL))
+		urls := make([]*url.URL, 0, len(BaseURL))
+		for i := range BaseURL {
+			profileURL, err := url.JoinPath(BaseURL[(start+i)%len(BaseURL)], screenName)
+			if err != nil {
+				logger.WithField("Mirror", BaseURL[(start+i)%len(BaseURL)]).
+					Warnf("构造用户页面地址失败：%v", err)
+				continue
+			}
+			parsedURL, err := url.Parse(profileURL)
+			if err != nil {
+				logger.WithField("Mirror", profileURL).Warnf("解析用户页面地址失败：%v", err)
+				continue
+			}
+			urls = append(urls, parsedURL)
+		}
+		return urls
 	}
 	Cookie *cookiejar.Jar
 )
@@ -142,47 +160,32 @@ func CSTTime(t time.Time) time.Time {
 }
 
 func (t *twitterConcern) FindUserInfo(id string, refresh bool) (*UserInfo, error) {
-retry:
 	var info *UserInfo
 	if refresh {
-		Url := buildProfileURL(id)
-		opts := SetRequestOptions()
-		var resp bytes.Buffer
-		var respHeaders requests.RespHeader
-		if err := requests.GetWithHeader(Url.String(), nil, &resp, &respHeaders, opts...); err != nil {
-			if err.Error() != ErrUnavailable && Url.Hostname() != "nitter.poast.org" {
-				logger.WithField("Mirror", Url.Hostname()).Errorf("查找用户失败：%v", err)
-				return nil, err
+		var profile *UserProfile
+		var lastErr error
+		for _, profileURL := range buildProfileURLs(id) {
+			profile, _, lastErr = fetchProfilePage(profileURL)
+			if lastErr == nil && profile != nil {
+				break
 			}
+			if lastErr == nil {
+				lastErr = errors.New("用户不存在或返回结果为空")
+			}
+			logger.WithField("Mirror", profileURL.Hostname()).WithField("User", id).
+				Warnf("查找用户失败，切换下一个镜像：%v", lastErr)
 		}
-
-		// 解压缩HTML
-		body, err := localutils.HtmlDecoder(respHeaders.ContentEncoding, resp)
-		if err != nil {
-			logger.WithField("Mirror", Url.Hostname()).
-				WithField("User", id).Errorf("解压缩HTML失败：%v", err)
-			return nil, err
-		}
-
-		// 解析用户信息
-		profile, _, challenge, err := ParseResp(body, Url.String())
-		if err != nil {
-			return nil, err
-		} else if challenge != nil && challenge.Type == "anubis" {
-			FreshCookie(challenge.Anubis)
-			goto retry
-		} else if challenge != nil && challenge.Type == "poast" {
-			time.Sleep(time.Second * 3)
-			goto retry
-		} else if profile == nil {
-			return nil, errors.New("用户不存在或返回结果为空")
+		if profile == nil {
+			if lastErr == nil {
+				lastErr = errors.New("没有可用的Twitter镜像")
+			}
+			return nil, fmt.Errorf("所有Twitter镜像均无法查询用户：%w", lastErr)
 		}
 		info = &UserInfo{
 			Id:   profile.ScreenName,
 			Name: profile.Name,
 		}
-		err = t.AddUserInfo(info)
-		if err != nil {
+		if err := t.AddUserInfo(info); err != nil {
 			return nil, err
 		}
 	}
@@ -562,45 +565,58 @@ func SetRequestOptions() []requests.Option {
 	}
 }
 
-func (t *twitterConcern) GetTweets(id string) ([]*Tweet, error) {
-retry:
-	Url := buildProfileURL(id)
-	opts := SetRequestOptions()
-	var resp bytes.Buffer
-	var respHeaders requests.RespHeader
-	if err := requests.GetWithHeader(Url.String(), nil, &resp, &respHeaders, opts...); err != nil {
-		if err.Error() != ErrUnavailable && Url.Hostname() != "nitter.poast.org" {
-			logger.WithField("Mirror", Url.Hostname()).WithField("userId", id).Errorf("获取推文列表失败：%v", err)
-			return nil, err
+func fetchProfilePage(profileURL *url.URL) (*UserProfile, []*Tweet, error) {
+	const maxChallengeAttempts = 2
+	for attempt := 0; attempt < maxChallengeAttempts; attempt++ {
+		opts := append(SetRequestOptions(), requests.RetryOption(0))
+		var resp bytes.Buffer
+		var respHeaders requests.RespHeader
+		if err := requests.GetWithHeader(profileURL.String(), nil, &resp, &respHeaders, opts...); err != nil {
+			return nil, nil, fmt.Errorf("请求失败：%w", err)
+		}
+
+		body, err := localutils.HtmlDecoder(respHeaders.ContentEncoding, resp)
+		if err != nil {
+			return nil, nil, fmt.Errorf("解压缩HTML失败：%w", err)
+		}
+
+		profile, tweets, challenge, err := ParseResp(body, profileURL.String())
+		if err != nil {
+			return nil, nil, fmt.Errorf("解析HTML失败：%w", err)
+		}
+		if challenge == nil {
+			return profile, tweets, nil
+		}
+		switch challenge.Type {
+		case "anubis":
+			FreshCookie(challenge.Anubis)
+		case "poast":
+			time.Sleep(time.Second * 3)
+		default:
+			return nil, nil, fmt.Errorf("不支持的镜像验证类型：%s", challenge.Type)
 		}
 	}
+	return nil, nil, errors.New("镜像验证重试次数已用尽")
+}
 
-	// 解压缩HTML
-	body, err := localutils.HtmlDecoder(respHeaders.ContentEncoding, resp)
-	if err != nil {
-		logger.WithField("Mirror", Url.Hostname()).
-			WithField("userId", id).Errorf("解压缩HTML失败：%v", err)
-		return nil, err
+func (t *twitterConcern) GetTweets(id string) ([]*Tweet, error) {
+	var lastErr error
+	for _, profileURL := range buildProfileURLs(id) {
+		_, tweets, err := fetchProfilePage(profileURL)
+		if err == nil && len(tweets) > 0 {
+			return tweets, nil
+		}
+		if err == nil {
+			err = errors.New("无法解析数据或推文列表为空")
+		}
+		lastErr = err
+		logger.WithField("Mirror", profileURL.Hostname()).WithField("userId", id).
+			Warnf("获取推文列表失败，切换下一个镜像：%v", err)
 	}
-
-	// 解析解压后的数据
-	_, tweets, challenge, err := ParseResp(body, Url.String())
-	if err != nil {
-		logger.WithField("Mirror", Url.Hostname()).
-			WithField("userId", id).Errorf("解析HTML失败：%v", err)
-		return nil, err
-	} else if challenge != nil && challenge.Type == "anubis" {
-		FreshCookie(challenge.Anubis)
-		goto retry
-	} else if challenge != nil && challenge.Type == "poast" {
-		time.Sleep(time.Second * 3)
-		goto retry
-	} else if tweets == nil {
-		logger.WithField("Mirror", Url.Hostname()).
-			WithField("userId", id).Warn("获取推文列表失败：无法解析数据或推文列表为空")
-		return nil, nil
+	if lastErr == nil {
+		lastErr = errors.New("没有可用的Twitter镜像")
 	}
-	return tweets, nil
+	return nil, fmt.Errorf("所有Twitter镜像均无法获取推文：%w", lastErr)
 }
 
 func (t *twitterConcern) Start() error {

--- a/lsp/twitter/concern_test.go
+++ b/lsp/twitter/concern_test.go
@@ -89,13 +89,13 @@ func TestTwitterConcern_GetUserInfo(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			// 替换 buildProfileURL
-			originalBuildProfileURL := buildProfileURL
-			buildProfileURL = func(screenName string) *url.URL {
+			// 替换 buildProfileURLs
+			originalBuildProfileURLs := buildProfileURLs
+			buildProfileURLs = func(screenName string) []*url.URL {
 				Url, _ := url.Parse(ts.URL)
-				return Url
+				return []*url.URL{Url}
 			}
-			defer func() { buildProfileURL = originalBuildProfileURL }()
+			defer func() { buildProfileURLs = originalBuildProfileURLs }()
 
 			tc := &twitterConcern{
 				StateManager: &StateManager{
@@ -337,13 +337,22 @@ TVアニメは7月6日(日)放送開始です！
 	}))
 	defer ts.Close()
 
-	// 替换 buildProfileURL 函数（需要修改 production 代码以支持此操作）
-	originalBuildProfileURL := buildProfileURL
-	buildProfileURL = func(screenName string) *url.URL {
-		Url, _ := url.Parse(ts.URL)
-		return Url
+	failedRequests := 0
+	failedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		failedRequests++
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`<html><head><title>Error | nitter</title></head><body><div class="error-panel">temporary error</div></body></html>`))
+	}))
+	defer failedServer.Close()
+
+	// 第一个镜像解析失败时，应自动切换到第二个镜像。
+	originalBuildProfileURLs := buildProfileURLs
+	buildProfileURLs = func(screenName string) []*url.URL {
+		failedURL, _ := url.Parse(failedServer.URL)
+		successURL, _ := url.Parse(ts.URL)
+		return []*url.URL{failedURL, successURL}
 	}
-	defer func() { buildProfileURL = originalBuildProfileURL }()
+	defer func() { buildProfileURLs = originalBuildProfileURLs }()
 
 	test.InitBuntdb(t)
 	defer test.CloseBuntdb(t)
@@ -366,6 +375,7 @@ TVアニメは7月6日(日)放送開始です！
 	assert.NoError(t, err)
 	assert.NotNil(t, tweets)
 	assert.Len(t, tweets, 5, "应解析出5条推文")
+	assert.Equal(t, 1, failedRequests, "失败镜像在单轮抓取中只应请求一次")
 
 	// 验证推文内容
 	tweet := tweets[0]
@@ -373,4 +383,38 @@ TVアニメは7月6日(日)放送開始です！
 	assert.Contains(t, tweet.Content, "ムツキ\n#ブルアカ #BlueArchive")
 	assert.Equal(t, int64(4117), tweet.Likes)
 	assert.Equal(t, int64(409), tweet.Retweets)
+}
+
+func TestTwitterConcern_GetTweets_AllMirrorsFailed(t *testing.T) {
+	failedRequests := 0
+	failedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		failedRequests++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer failedServer.Close()
+
+	originalBuildProfileURLs := buildProfileURLs
+	buildProfileURLs = func(screenName string) []*url.URL {
+		firstURL, _ := url.Parse(failedServer.URL + "/first")
+		secondURL, _ := url.Parse(failedServer.URL + "/second")
+		return []*url.URL{firstURL, secondURL}
+	}
+	defer func() { buildProfileURLs = originalBuildProfileURLs }()
+
+	tweets, err := new(twitterConcern).GetTweets("testuser")
+
+	assert.Nil(t, tweets)
+	assert.ErrorContains(t, err, "所有Twitter镜像均无法获取推文")
+	assert.Equal(t, 2, failedRequests, "全部镜像失败后才应返回错误")
+}
+
+func TestBuildProfileURLs_NormalizesPath(t *testing.T) {
+	originalBaseURL := BaseURL
+	BaseURL = []string{"https://example.com/nitter"}
+	defer func() { BaseURL = originalBaseURL }()
+
+	urls := buildProfileURLs("GenshinImpact")
+
+	assert.Len(t, urls, 1)
+	assert.Equal(t, "https://example.com/nitter/GenshinImpact", urls[0].String())
 }


### PR DESCRIPTION
## 问题

Twitter mirror模式的新增订阅会先刷新一次用户推文。当前实现随机选择一个镜像，并在该镜像上进行普通请求重试；一旦镜像返回429/503、错误页、解析失败或空结果，本轮刷新便直接失败，即使配置列表中的其他镜像仍可使用。

实际表现为新增订阅在随机选中的镜像临时失败时直接返回“刷新用户推文失败”，没有继续尝试配置中的其他镜像。

## 实现

- 每轮抓取从随机起点开始，依次尝试配置中的所有镜像，任一成功即返回。
- HTTP错误、错误页、HTML解析失败和空推文结果均切换到下一个镜像；全部失败后才向上层返回错误。
- 取消单个镜像内部的三次普通请求重试，避免持续等待已故障的源。
- Anubis和Poast挑战仍允许在当前镜像内最多处理两次。
- 使用`url.JoinPath`构造用户页面地址，配置末尾是否包含斜杠均可正确拼接。
- 用户资料刷新和推文列表刷新共用同一换源逻辑。

## 验证

- `CGO_ENABLED=0 go test ./lsp/twitter ./lsp/concern`
- `CGO_ENABLED=0 go build -pgo=auto ./cmd`
- 新增回归测试覆盖：首个镜像失败后切换成功、全部镜像失败后才报错、无尾斜杠URL规范化。

## 已知边界

- 本改动不会保证外部镜像可用；当配置中的所有镜像均失败时，订阅仍会返回失败。
- 未修改Twitter API模式。
